### PR TITLE
feat: update UI/UX for crypto payments and send screen:

### DIFF
--- a/apps/telegram-ecash-escrow/src/app/my-offer/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/my-offer/page.tsx
@@ -159,12 +159,16 @@ export default function MyOffer() {
                         // Issue: All custom useInfinite hooks have a mismatch between loading state and data.
                         // When loading state is false, data should have but it not available shortly afterward,
                         // leading to a delay in synchronization.
-                        dataOfferActive.length === 0 && (
+                        dataOfferActive.length === 0 && dataOfferArchive.length === 0 ? (
                           <Typography className="end-message" component={'div'}>
-                            <Typography>You haven't got any offer yet.</Typography>
+                            <Typography> You haven't created any offer yet</Typography>
                             <Button variant="contained" onClick={() => handleOpenCreateOffer()}>
                               Create my first offer
                             </Button>
+                          </Typography>
+                        ) : (
+                          <Typography style={{ textAlign: 'center', marginTop: '2rem' }}>
+                            No active offer here
                           </Typography>
                         )
                       }

--- a/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
@@ -598,7 +598,7 @@ const OrderDetail = () => {
           Your wallet: {totalBalanceFormat} {COIN.XEC}
         </Typography>
         <Typography>
-          Security fee (1%): {fee1Percent.toLocaleString('de-DE')} {COIN.XEC}
+          Security deposit (1%): {fee1Percent.toLocaleString('de-DE')} {COIN.XEC}
         </Typography>
         <Typography>
           Withdraw fee: {estimatedFee(currentData?.escrowOrder.escrowScript).toLocaleString('de-DE')} {COIN.XEC}

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
@@ -141,13 +141,16 @@ const PlaceAnOrderWrap = styled('div')(({ theme }) => ({
   '.payment-method-wrap': {
     display: 'flex',
     flexDirection: 'row',
-    gap: 16,
-    justifyContent: 'space-between',
+    alignItems: 'center',
     margin: '16px 0',
     '.MuiFormControlLabel-root': {
       '.MuiTypography-root': {
         fontSize: 14
       }
+    },
+
+    '.label-coinOthers': {
+      height: 30
     }
   },
 
@@ -432,7 +435,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
           Your wallet: {totalBalanceFormat} {COIN.XEC}
         </Typography>
         <Typography component="p" variant="body1">
-          Security fee (1%): {fee1Percent.toLocaleString('de-DE')} {COIN.XEC}
+          Security deposit (1%): {fee1Percent.toLocaleString('de-DE')} {COIN.XEC}
         </Typography>
       </div>
     );
@@ -662,14 +665,19 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
                   />
                 );
               })}
+              {post.postOffer?.coinOthers && (
+                <Button size="small" color="success" variant="contained" className="label-coinOthers">
+                  {post.postOffer.coinOthers}
+                </Button>
+              )}
               {errors.paymentMethod && (
                 <Typography color="error">{errors?.paymentMethod?.message as string}</Typography>
               )}
             </RadioGroup>
             <div className="disclaim-wrap">
               <Typography className="title" variant="body2">
-                * Deposit a security fee to have a higher chance of being accepted. The security fee will be returned if
-                there is no dispute.
+                * Deposit a security deposit to have a higher chance of being accepted. The security deposit will be
+                returned if there is no dispute.
               </Typography>
               <Controller
                 name="isDepositFee"
@@ -678,7 +686,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
                 render={({ field: { onChange, onBlur, value, ref } }) => (
                   <FormControlLabel
                     control={<Checkbox onChange={onChange} onBlur={onBlur} checked={value} inputRef={ref} />}
-                    label={`I want to deposit security fee (1%): ${calDisputeFee} XEC`}
+                    label={`I want to deposit security deposit (1%): ${calDisputeFee} XEC`}
                   />
                 )}
               />

--- a/apps/telegram-ecash-escrow/src/components/Send/send.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Send/send.tsx
@@ -37,6 +37,18 @@ const WrapComponent = styled.div`
     margin-top: 10px;
     color: #fff;
   }
+
+  .MuiFormControlLabel-root {
+    margin-top: 7px;
+  }
+
+  .amount-donate-gnc {
+    font-size: 14px;
+  }
+
+  .bold {
+    font-weight: bold;
+  }
 `;
 interface SendComponentProps {
   totalValidAmount: number;
@@ -61,7 +73,7 @@ const SendComponent: React.FC<SendComponentProps> = props => {
     defaultValues: {
       address: '',
       amount: 0,
-      isDonateGNC: true
+      isDonateGNC: false
     }
   });
 
@@ -231,8 +243,11 @@ const SendComponent: React.FC<SendComponentProps> = props => {
           )}
         />
         {isDonateGNC && (
-          <Typography>
-            {calFee1Percent.toLocaleString('de-DE')} {COIN.XEC} will be sent to Local eCash to maintains this app
+          <Typography className="amount-donate-gnc">
+            <span className="bold">
+              {calFee1Percent.toLocaleString('de-DE')} {COIN.XEC}{' '}
+            </span>{' '}
+            will be sent to Local eCash to maintains this app
           </Typography>
         )}
       </div>


### PR DESCRIPTION
- Made "Make Donation" optional on the Send screen.
- Renamed "Security fee" to "Security deposit".
- Added "Ticker for Others" option in crypto payment under "Place an Order".