### PR TITLE
feat: Enhance backup flow and offer-related features, fix UI…

### DIFF
--- a/apps/telegram-ecash-escrow/src/app/backup/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/backup/page.tsx
@@ -7,6 +7,7 @@ import {
   getSelectedAccountId,
   getWalletMnemonic,
   settingApi,
+  updateSeedBackupTime,
   useSliceDispatch as useLixiSliceDispatch,
   useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
@@ -93,24 +94,31 @@ export default function Backup() {
   const [libWord, setLibWord] = useState<string[]>([]);
   const [randomListFinal, setRandomListFinal] = useState<string[]>([]);
   const [finished, setFinished] = useState(false);
+  const [disableButton, setDisableButton] = useState(false);
 
   const router = useRouter();
   const finalStep = async () => {
     //set time backup
     try {
+      const currentTime = new Date();
       const updateSettingCommand: UpdateSettingCommand = {
         accountId: selectedAccountId,
-        lastSeedBackupTime: new Date()
+        lastSeedBackupTime: currentTime
       };
       if (selectedAccountId) {
+        //setting on server
         const updatedSetting = await settingApi.updateSetting(updateSettingCommand);
         setSetting(updatedSetting);
+
+        //set backup time on device
+        dispatch(updateSeedBackupTime(currentTime.toISOString()));
       }
     } catch (err) {
       console.log('err when update setting: ', err);
     }
 
     setFinished(true);
+    setDisableButton(true);
     //router after 2s
     setTimeout(() => {
       const isFromSetting = searchParams.get('isFromSetting');
@@ -205,7 +213,7 @@ export default function Backup() {
     <MobileLayout>
       <ContainerBackupGame>
         <div className="setting-info">
-          <IconButton className="back-btn" onClick={() => router.back()}>
+          <IconButton disabled={disableButton} className="back-btn" onClick={() => router.back()}>
             <Close />
           </IconButton>
           <Typography variant="h5">{!isPlayGame ? 'Your recovery phrase' : 'Verify your phrase'}</Typography>
@@ -260,6 +268,7 @@ export default function Backup() {
             }}
             variant="contained"
             fullWidth
+            disabled={disableButton}
           >
             Back
           </Button>

--- a/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
@@ -565,7 +565,7 @@ const OrderDetail = () => {
       isSeller && (
         <QRCode
           address={parseCashAddressToPrefix(COIN.XEC, selectedWalletPath?.cashAddress)}
-          amount={totalAmountWithDepositAndEscrowFee()}
+          amount={Number(totalAmountWithDepositAndEscrowFee().toFixed(2))}
           width="60%"
         />
       )

--- a/apps/telegram-ecash-escrow/src/app/wallet/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/wallet/page.tsx
@@ -10,6 +10,7 @@ import { SettingContext } from '@/src/store/context/settingProvider';
 import { UtxoContext } from '@/src/store/context/utxoProvider';
 import { COIN } from '@bcpros/lixi-models';
 import {
+  getSeedBackupTime,
   getSelectedWalletPath,
   openModal,
   parseCashAddressToPrefix,
@@ -89,8 +90,9 @@ export default function Wallet() {
   const dispatch = useLixiSliceDispatch();
 
   const selectedWalletPath = useLixiSliceSelector(getSelectedWalletPath);
+  const lastSeedBackupTimeOnDevice = useLixiSliceSelector(getSeedBackupTime);
   const settingContext = useContext(SettingContext);
-  const seedBackupTime = settingContext?.setting?.lastSeedBackupTime ?? '';
+  const seedBackupTime = settingContext?.setting?.lastSeedBackupTime ?? lastSeedBackupTimeOnDevice ?? '';
 
   const [address, setAddress] = useState(parseCashAddressToPrefix(COIN.XEC, selectedWalletPath?.cashAddress));
   const [openReceive, setOpenReceive] = useState(true);

--- a/apps/telegram-ecash-escrow/src/components/ActionSheet/OfferActionSheet.tsx
+++ b/apps/telegram-ecash-escrow/src/components/ActionSheet/OfferActionSheet.tsx
@@ -1,6 +1,6 @@
 import {
-  OfferQueryItem,
   OfferStatus,
+  PostQueryItem,
   UpdateOfferStatusInput,
   closeActionSheet,
   offerApi,
@@ -26,11 +26,13 @@ const ListStyled = styled(List)(({ theme }) => ({
 }));
 
 interface OfferActionSheetProps {
-  offer: OfferQueryItem;
+  post: PostQueryItem;
 }
 
-export default function OfferActionSheet({ offer }: OfferActionSheetProps) {
+export default function OfferActionSheet({ post }: OfferActionSheetProps) {
+  const offer = post?.postOffer;
   const dispatch = useLixiSliceDispatch();
+
   const [open, setOpen] = useState(true);
 
   const { useUpdateOfferStatusMutation } = offerApi;
@@ -49,6 +51,10 @@ export default function OfferActionSheet({ offer }: OfferActionSheetProps) {
     triggerUpdateOfferStatus({ input });
   };
 
+  const handleBoostOffer = async () => {
+    dispatch(openModal('BoostModal', { post: post }));
+  };
+
   const handleClose = () => {
     setOpen(false);
     setTimeout(() => {
@@ -64,9 +70,14 @@ export default function OfferActionSheet({ offer }: OfferActionSheetProps) {
             <ListItemText primary={'Edit offer'} />
           </ListItemButton>
         </ListItem>
-        <ListItem key={'Archived'} disablePadding>
+        <ListItem key={'Archive'} disablePadding>
           <ListItemButton onClick={handleClickArchive}>
-            <ListItemText primary={'Archived offer'} />
+            <ListItemText primary={'Archive offer'} />
+          </ListItemButton>
+        </ListItem>
+        <ListItem key={'Boost'} disablePadding>
+          <ListItemButton onClick={handleBoostOffer}>
+            <ListItemText primary={'Boost offer'} />
           </ListItemButton>
         </ListItem>
       </ListStyled>

--- a/apps/telegram-ecash-escrow/src/components/BoostModal/BoostModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/BoostModal/BoostModal.tsx
@@ -7,6 +7,7 @@ import {
   boostApi,
   BoostForType,
   BoostType,
+  closeActionSheet,
   closeModal,
   CreateBoostInput,
   getSelectedWalletPath,
@@ -16,17 +17,8 @@ import {
 } from '@bcpros/redux-store';
 import { styled } from '@mui/material/styles';
 
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Portal,
-  Slide,
-  Typography,
-  useTheme
-} from '@mui/material';
+import { BOOST_AMOUNT } from '@/src/store/constants';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Portal, Slide, Typography } from '@mui/material';
 import { TransitionProps } from '@mui/material/transitions';
 import { fromHex, toHex } from 'ecash-lib';
 import cashaddr from 'ecashaddrjs';
@@ -85,7 +77,6 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
 }));
 
 interface BoostModalProps {
-  amount: number;
   post: PostQueryItem;
   classStyle?: string;
 }
@@ -99,12 +90,11 @@ const Transition = React.forwardRef(function Transition(
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-const BoostModal: React.FC<BoostModalProps> = ({ amount, post }: BoostModalProps) => {
+const BoostModal: React.FC<BoostModalProps> = ({ post }: BoostModalProps) => {
   const { totalValidAmount, totalValidUtxos } = useContext(UtxoContext);
 
   const dispatch = useLixiSliceDispatch();
   const selectedWallet = useLixiSliceSelector(getSelectedWalletPath);
-  const theme = useTheme();
 
   const [error, setError] = useState(false);
   const [notEnoughMoney, setNotEnoughMoney] = useState(false);
@@ -127,6 +117,7 @@ const BoostModal: React.FC<BoostModalProps> = ({ amount, post }: BoostModalProps
       const { hash: hashXEC } = cashaddr.decode(GNCAddress, false);
       const GNCHash = Buffer.from(hashXEC).toString('hex');
 
+      const amount = BOOST_AMOUNT;
       if (totalValidAmount < amount) {
         setNotEnoughMoney(true);
       }
@@ -181,6 +172,7 @@ const BoostModal: React.FC<BoostModalProps> = ({ amount, post }: BoostModalProps
           handleClose={() => {
             setBoostSuccess(false);
             handleCloseModal();
+            dispatch(closeActionSheet());
           }}
           content="Boost offer successful"
           type="success"
@@ -190,6 +182,7 @@ const BoostModal: React.FC<BoostModalProps> = ({ amount, post }: BoostModalProps
           handleClose={() => {
             setError(false);
             handleCloseModal();
+            dispatch(closeActionSheet());
           }}
           content="Boost offer failed!"
           type="error"
@@ -200,6 +193,7 @@ const BoostModal: React.FC<BoostModalProps> = ({ amount, post }: BoostModalProps
           handleClose={() => {
             setNotEnoughMoney(false);
             handleCloseModal();
+            dispatch(closeActionSheet());
           }}
           content="Not enough XEC to boost!"
           type="error"

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { COIN_OTHERS, LIST_COIN } from '@/src/store/constants';
+import { COIN_OTHERS, COIN_USD_STABLECOIN_TICKET, LIST_COIN } from '@/src/store/constants';
 import { LIST_CURRENCIES_USED, Location } from '@bcpros/lixi-models';
 import {
   Coin,
@@ -537,7 +537,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
                         if (item.ticker === 'XEC') return;
                         return (
                           <option key={item.ticker} value={`${item.ticker}:${item.fixAmount}`}>
-                            {item.name} ({item.ticker})
+                            {item.name} {item.ticker !== COIN_USD_STABLECOIN_TICKET && `(${item.ticker})`}
                           </option>
                         );
                       })}

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -4,12 +4,14 @@ import { COIN_OTHERS } from '@/src/store/constants';
 import { SettingContext } from '@/src/store/context/settingProvider';
 import { formatNumber } from '@/src/store/util';
 import {
+  getSeedBackupTime,
   OfferStatus,
   openActionSheet,
   openModal,
   PostQueryItem,
   TimelineQueryItem,
-  useSliceDispatch as useLixiSliceDispatch
+  useSliceDispatch as useLixiSliceDispatch,
+  useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { Button, IconButton, Typography } from '@mui/material';
@@ -46,13 +48,18 @@ const OfferDetailWrap = styled('div')(({ theme }) => ({
     color: '#79869b'
   },
 
-  '.payment-group-btns': {
+  '.action-section': {
     display: 'flex',
-    flexWrap: 'wrap',
-    gap: '10px',
+    justifyContent: 'space-between',
     button: {
       borderRadius: '10px',
       textTransform: 'capitalize'
+    },
+
+    '.payment-group-btns': {
+      button: {
+        marginRight: '10px'
+      }
     }
   }
 }));
@@ -70,8 +77,9 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
   const { status } = useSession();
   const askAuthorization = useAuthorization();
 
+  const lastSeedBackupTimeOnDevice = useLixiSliceSelector(getSeedBackupTime);
   const settingContext = useContext(SettingContext);
-  const seedBackupTime = settingContext?.setting?.lastSeedBackupTime ?? '';
+  const seedBackupTime = settingContext?.setting?.lastSeedBackupTime ?? lastSeedBackupTimeOnDevice ?? '';
 
   const postData = timelineItem?.data as PostQueryItem;
   const offerData = postData?.postOffer ?? post?.postOffer;
@@ -81,7 +89,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
 
   const handleClickAction = e => {
     e.stopPropagation();
-    dispatch(openActionSheet('OfferActionSheet', { offer: offerData }));
+    dispatch(openActionSheet('OfferActionSheet', { post: postData }));
   };
 
   const handleBuyClick = e => {
@@ -154,21 +162,23 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
           {offerData.noteOffer}
         </Typography>
       )}
-      <div className="payment-group-btns">
-        {offerData?.paymentMethods &&
-          offerData.paymentMethods?.length > 0 &&
-          offerData.paymentMethods.map(item => {
-            return (
-              <Button size="small" color="success" variant="outlined" key={item.paymentMethod.name}>
-                {item.paymentMethod.name}
-              </Button>
-            );
-          })}
-        {offerData?.coinOthers && (
-          <Button size="small" color="success" variant="outlined">
-            {offerData.coinOthers}
-          </Button>
-        )}
+      <div className="action-section">
+        <div className="payment-group-btns">
+          {offerData?.paymentMethods &&
+            offerData.paymentMethods?.length > 0 &&
+            offerData.paymentMethods.map(item => {
+              return (
+                <Button size="small" color="success" variant="outlined" key={item.paymentMethod.name}>
+                  {item.paymentMethod.name}
+                </Button>
+              );
+            })}
+          {offerData?.coinOthers && (
+            <Button size="small" color="success" variant="outlined">
+              {offerData.coinOthers}
+            </Button>
+          )}
+        </div>
         {isShowBuyButton && (
           <BuyButtonStyled variant="contained" onClick={e => handleBuyClick(e)}>
             Buy

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
@@ -163,12 +163,12 @@ const OrderDetailInfo = ({ item }: OrderItemProps) => {
         </div>
         <div className="order-type">
           {order?.sellerAccount.id === selectedAccount?.id && (
-            <Button className="btn-order-type" size="small" color="info" variant="outlined">
+            <Button className="btn-order-type" size="small" color="error" variant="outlined">
               Sell
             </Button>
           )}
           {order?.buyerAccount.id === selectedAccount?.id && (
-            <Button className="btn-order-type" size="small" color="info" variant="outlined">
+            <Button className="btn-order-type" size="small" color="success" variant="outlined">
               Buy
             </Button>
           )}

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
@@ -1,23 +1,23 @@
 'use client';
 
-import { COIN_OTHERS } from '@/src/store/constants';
+import { COIN_OTHERS, COIN_USD_STABLECOIN_TICKET } from '@/src/store/constants';
 import { UtxoContext } from '@/src/store/context/utxoProvider';
-import { buyerDepositFee, Escrow, splitUtxos } from '@/src/store/escrow';
+import { Escrow, buyerDepositFee, splitUtxos } from '@/src/store/escrow';
 import { convertXECToSatoshi, estimatedFee } from '@/src/store/util';
-import { COIN, coinInfo, CreateEscrowOrderInput } from '@bcpros/lixi-models';
+import { COIN, CreateEscrowOrderInput, coinInfo } from '@bcpros/lixi-models';
 import {
+  PostQueryItem,
+  UtxoInNodeInput,
+  WalletContextNode,
   closeModal,
   convertEscrowScriptHashToEcashAddress,
   escrowOrderApi,
   fiatCurrencyApi,
   getSelectedWalletPath,
   parseCashAddressToPrefix,
-  PostQueryItem,
   showToast,
   useSliceDispatch as useLixiSliceDispatch,
-  useSliceSelector as useLixiSliceSelector,
-  UtxoInNodeInput,
-  WalletContextNode
+  useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
 import { ChevronLeft } from '@mui/icons-material';
 import {
@@ -42,7 +42,7 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { TransitionProps } from '@mui/material/transitions';
-import { fromHex, Script, shaRmd160 } from 'ecash-lib';
+import { Script, fromHex, shaRmd160 } from 'ecash-lib';
 import _ from 'lodash';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
@@ -447,7 +447,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
     let amountCoinOrCurrency = 0;
     const textAmountPer1MXEC = 1000000;
     //if payment is crypto, we convert from coin => USD => XEC
-    if (post?.postOffer?.coinPayment) {
+    if (post?.postOffer?.coinPayment && post?.postOffer?.coinPayment !== COIN_USD_STABLECOIN_TICKET) {
       const coinPayment = post.postOffer.coinPayment.toLowerCase();
       const rateArrayCoin = rateData.find(item => item.coin === coinPayment);
       const rateArrayXec = rateData.find(item => item.coin === 'xec');

--- a/apps/telegram-ecash-escrow/src/store/constants.ts
+++ b/apps/telegram-ecash-escrow/src/store/constants.ts
@@ -9,6 +9,8 @@ export enum TabType {
 }
 
 export const COIN_OTHERS = 'Others';
+export const COIN_USD_STABLECOIN = 'USD Stablecoins';
+export const COIN_USD_STABLECOIN_TICKET = 'USD';
 
 export const LIST_COIN = [
   {
@@ -52,6 +54,12 @@ export const LIST_COIN = [
     name: 'LiteCoin',
     ticker: 'LTC',
     fixAmount: 100
+  },
+  {
+    id: 9,
+    name: COIN_USD_STABLECOIN,
+    ticker: COIN_USD_STABLECOIN_TICKET,
+    fixAmount: 100
   }
 ];
 
@@ -60,3 +68,5 @@ export const THEMES_TYPE = {
   DARK: 'dark',
   SYSTEM: 'system'
 };
+
+export const BOOST_AMOUNT = 100;

--- a/apps/telegram-ecash-escrow/src/store/context/settingProvider.tsx
+++ b/apps/telegram-ecash-escrow/src/store/context/settingProvider.tsx
@@ -1,5 +1,11 @@
 import { Setting } from '@bcpros/lixi-models';
-import { getSelectedAccount, settingApi, useSliceSelector as useLixiSliceSelector } from '@bcpros/redux-store';
+import {
+  getSelectedAccount,
+  settingApi,
+  updateSeedBackupTime,
+  useSliceDispatch as useLixiSliceDispatch,
+  useSliceSelector as useLixiSliceSelector
+} from '@bcpros/redux-store';
 import _ from 'lodash';
 import { createContext, useEffect, useMemo, useState } from 'react';
 
@@ -12,6 +18,7 @@ export interface SettingContextType {
 export const SettingContext = createContext<SettingContextType>(undefined);
 
 export function SettingProvider({ children }) {
+  const dispatch = useLixiSliceDispatch();
   const selectedAccount = useLixiSliceSelector(getSelectedAccount);
   const [setting, setSetting] = useState<Setting>(null);
   const [token, setToken] = useState<string | null>(sessionStorage.getItem('Authorization'));
@@ -41,7 +48,7 @@ export function SettingProvider({ children }) {
 
       return () => clearInterval(interval);
     }
-  }, []);
+  }, [selectedAccount]);
 
   //get setting
   useEffect(() => {
@@ -49,6 +56,9 @@ export function SettingProvider({ children }) {
       (async () => {
         const data = (await getSetting(selectedAccount?.id)) as Setting;
         setSetting(data);
+
+        //set backup time on device
+        dispatch(updateSeedBackupTime(data?.lastSeedBackupTime?.toString()));
       })();
     }
   }, [selectedAccount?.id, token]);

--- a/apps/telegram-ecash-escrow/src/store/context/utxoProvider.tsx
+++ b/apps/telegram-ecash-escrow/src/store/context/utxoProvider.tsx
@@ -3,6 +3,7 @@ import {
   UtxoInNode,
   UtxoInNodeInput,
   escrowOrderApi,
+  getSelectedAccount,
   getSlpBalancesAndUtxosNode,
   useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
@@ -19,6 +20,7 @@ export const UtxoContext = createContext<UtxoContextType>(undefined);
 export function UtxoProvider({ children }) {
   const [token, setToken] = useState<string | null>(sessionStorage.getItem('Authorization'));
   const utxosNode = useLixiSliceSelector(getSlpBalancesAndUtxosNode);
+  const selectedAccount = useLixiSliceSelector(getSelectedAccount);
 
   const [totalValidAmount, setTotalValidAmount] = useState<number>(0);
   const [totalValidUtxos, setTotalValidUtxos] = useState([]);
@@ -47,7 +49,7 @@ export function UtxoProvider({ children }) {
 
       return () => clearInterval(interval);
     }
-  }, []);
+  }, [selectedAccount]);
 
   // Call to validate UTXOs
   useEffect(() => {


### PR DESCRIPTION
 and bot message bugs

- Revisit and improve backup flow (#174)
- Disable the backup button once finished
- Update label "Archived offer" to "Archive offer" (#216)
- Add distinct color labels for Sell and Buy orders (#218)
- Fix issue where balance is not displayed after first-time key import (#219)
- Correct QR code decimals for deposit in escrow (#220)
- Add Boost button in My Offers tab for easier offer boosting (#222)
- Fix incorrect USD min/max in offer bot messages (#231)
- Link bot messages to offer details with a button to open it (#232)
- Support USD Stablecoins for Crypto payment option (#234)
- Improve UI for Buy button in offer-detail view