### PR TITLE
Update March:

### DIFF
--- a/apps/telegram-ecash-escrow/src/app/import/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/import/page.tsx
@@ -272,7 +272,7 @@ export default function ImportWallet() {
       <ConfirmCreateNewAccountModal
         isOpen={openConfirmCreateAccount}
         isLoading={loading}
-        onDissmissModal={value => setOpenConfirmCreateAccount(value)}
+        onDismissModal={value => setOpenConfirmCreateAccount(value)}
         createAccount={isCreateAccount => {
           if (isCreateAccount) {
             handleCreateNewWallet();

--- a/apps/telegram-ecash-escrow/src/app/import/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/import/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import ConfirmCreateNewAccountModal from '@/src/components/Auth/ConfirmCreateNewAccountModal';
 import CustomToast from '@/src/components/Toast/CustomToast';
 import MobileLayout from '@/src/components/layout/MobileLayout';
 import { AccountType, COIN, GenerateAccountType, ImportAccountType } from '@bcpros/lixi-models';
@@ -97,16 +98,10 @@ export default function ImportWallet() {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
   const [success, setSuccess] = useState<boolean>(false);
+  const [openConfirmCreateAccount, setOpenConfirmCreateAccount] = useState(false);
+
   const { getXecWalletPublicKey } = useContext(WalletContextNode);
   const selectedWalletPath = useLixiSliceSelector(getSelectedWalletPath);
-
-  const scanQRCode = () => {
-    // haptic.notificationOccurred('warning');
-    // scanner.open('Scan the seed phrase').then((content) => {
-    //   setSeedPhrase(content || '');
-    //   scanner.close();
-    // });
-  };
 
   useEffect(() => {
     selectedWalletPath && router.push('/');
@@ -217,7 +212,7 @@ export default function ImportWallet() {
                   InputProps={{
                     endAdornment: (
                       <InputAdornment position="end">
-                        <div onClick={scanQRCode}>
+                        <div>
                           <QrCodeScannerOutlinedIcon />
                         </div>
                       </InputAdornment>
@@ -248,7 +243,7 @@ export default function ImportWallet() {
           <Button
             className="btn-create"
             variant="contained"
-            onClick={() => handleCreateNewWallet()}
+            onClick={() => setOpenConfirmCreateAccount(true)}
             disabled={loading || success}
           >
             Create new wallet
@@ -273,6 +268,19 @@ export default function ImportWallet() {
           />
         </Stack>
       </ContainerImportWallet>
+
+      <ConfirmCreateNewAccountModal
+        isOpen={openConfirmCreateAccount}
+        isLoading={loading}
+        onDissmissModal={value => setOpenConfirmCreateAccount(value)}
+        createAccount={isCreateAccount => {
+          if (isCreateAccount) {
+            handleCreateNewWallet();
+          } else {
+            setOpenConfirmCreateAccount(false);
+          }
+        }}
+      />
     </MobileLayout>
   );
 }

--- a/apps/telegram-ecash-escrow/src/app/offer-detail/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/offer-detail/page.tsx
@@ -3,7 +3,9 @@
 import OfferDetailInfo from '@/src/components/DetailInfo/OfferDetailInfo';
 import OrderDetailInfo from '@/src/components/DetailInfo/OrderDetailInfo';
 import MobileLayout from '@/src/components/layout/MobileLayout';
+import { TabPanel } from '@/src/components/Tab/Tab';
 import TickerHeader from '@/src/components/TickerHeader/TickerHeader';
+import { TabType } from '@/src/store/constants';
 import {
   EscrowOrderQueryItem,
   EscrowOrderStatus,
@@ -12,12 +14,13 @@ import {
   useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
 import { usePostQuery } from '@bcpros/redux-store/build/main/store/post/posts.api';
-import { Button, CircularProgress, Skeleton, Stack, Typography } from '@mui/material';
+import { Box, CircularProgress, Skeleton, Tab, Tabs, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import _ from 'lodash';
 import { useSearchParams } from 'next/navigation';
 import React, { useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
+import SwipeableViews from 'react-swipeable-views';
 
 const OfferDetailPage = styled('div')(({ theme }) => ({
   minHeight: '100vh',
@@ -45,8 +48,25 @@ const OfferDetailPage = styled('div')(({ theme }) => ({
     '.active': {
       border: '1px solid rgba(255, 255, 255, 1)'
     }
+  },
+
+  '.MuiTab-root': {
+    color: theme.custom.colorItem,
+    textTransform: 'none',
+    fontWeight: 600,
+    fontSize: '16px',
+
+    '&.Mui-selected': {
+      backgroundColor: 'rgba(255, 255, 255, 0.08)',
+      backdropFilter: 'blur(8px)'
+    }
+  },
+
+  '.MuiTabs-indicator': {
+    backgroundColor: theme.palette.primary.main || '#0076c4'
   }
 }));
+
 const OfferDetail = () => {
   const token = sessionStorage.getItem('Authorization');
   const search = useSearchParams();
@@ -54,6 +74,7 @@ const OfferDetail = () => {
 
   const selectedAccount = useLixiSliceSelector(getSelectedAccount);
 
+  const [value, setValue] = useState<TabType>(TabType.PENDING);
   const [orderStatus, setOrderStatus] = useState<EscrowOrderStatus>(EscrowOrderStatus.Pending);
 
   const { currentData, isError } = usePostQuery({ id: id! }, { skip: !id });
@@ -76,10 +97,75 @@ const OfferDetail = () => {
     }
   };
 
+  const handleChange = (event: React.SyntheticEvent, newValue: TabType) => {
+    setOrderStatus(getOrderStatus(newValue));
+    setValue(newValue);
+  };
+
+  const handleChangeIndex = (index: number) => {
+    const tabValues = [TabType.PENDING, TabType.ESCROWED, TabType.ARCHIVED];
+    setOrderStatus(getOrderStatus(tabValues[index]));
+    setValue(tabValues[index]);
+  };
+
+  const getTabIndex = (tabValue: TabType): number => {
+    switch (tabValue) {
+      case TabType.PENDING:
+        return 0;
+      case TabType.ESCROWED:
+        return 1;
+      case TabType.ARCHIVED:
+        return 2;
+      default:
+        return 0;
+    }
+  };
+
+  const getOrderStatus = (tabValue: TabType) => {
+    switch (tabValue) {
+      case TabType.PENDING:
+        return EscrowOrderStatus.Pending;
+      case TabType.ESCROWED:
+        return EscrowOrderStatus.Escrow;
+      case TabType.ARCHIVED:
+        return EscrowOrderStatus.Complete;
+      default:
+        return EscrowOrderStatus.Pending;
+    }
+  };
+
   if (_.isEmpty(id) || _.isNil(id) || isError) {
     return <div style={{ color: 'white' }}>Invalid offer id</div>;
   }
 
+  const ListItem = () => {
+    return !isFetchingEscrowOrders ? (
+      escrowOrdersData.length > 0 ? (
+        <InfiniteScroll
+          dataLength={escrowOrdersData.length}
+          next={loadMoreEscrowOrders}
+          hasMore={hasNextEscrowOrders}
+          loader={
+            <>
+              <Skeleton variant="text" />
+              <Skeleton variant="text" />
+            </>
+          }
+          scrollableTarget="scrollableDiv"
+        >
+          {escrowOrdersData.map(item => {
+            return <OrderDetailInfo item={item.data as EscrowOrderQueryItem} key={item.id} />;
+          })}
+        </InfiniteScroll>
+      ) : (
+        <Typography style={{ textAlign: 'center', marginTop: '2rem' }}>No orders here</Typography>
+      )
+    ) : (
+      <Box sx={{ height: '50vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <CircularProgress color="primary" />
+      </Box>
+    );
+  };
   const ListButtonComponent = () => {
     const isAccountOffer = currentData && currentData?.post?.accountId === selectedAccount?.id;
     if (!token || !isAccountOffer) {
@@ -88,65 +174,37 @@ const OfferDetail = () => {
 
     return (
       <>
-        <div className="list-item">
-          <hr />
-          <Stack className="group-btn-order" direction="row" gap="20px" justifyContent="center">
-            <Button
-              onClick={() => setOrderStatus(EscrowOrderStatus.Pending)}
-              className={`btn-timeline ${orderStatus === EscrowOrderStatus.Pending ? 'active' : ''}`}
-              color="warning"
-              variant="contained"
-            >
-              {EscrowOrderStatus.Pending}
-            </Button>
-            <Button
-              onClick={() => setOrderStatus(EscrowOrderStatus.Escrow)}
-              className={`btn-timeline ${orderStatus === EscrowOrderStatus.Escrow ? 'active' : ''}`}
-              color="info"
-              variant="contained"
-            >
-              {EscrowOrderStatus.Escrow}
-            </Button>
-            <Button
-              onClick={() => setOrderStatus(EscrowOrderStatus.Complete)}
-              className={`btn-timeline ${orderStatus === EscrowOrderStatus.Complete ? 'active' : ''}`}
-              color="success"
-              variant="contained"
-            >
-              {EscrowOrderStatus.Complete}
-            </Button>
-            <Button
-              onClick={() => setOrderStatus(EscrowOrderStatus.Cancel)}
-              className={`btn-timeline ${orderStatus === EscrowOrderStatus.Cancel ? 'active' : ''}`}
-              color="error"
-              variant="contained"
-            >
-              {EscrowOrderStatus.Cancel}
-            </Button>
-          </Stack>
-          {escrowOrdersData?.length > 0 ? (
-            <InfiniteScroll
-              dataLength={escrowOrdersData.length}
-              next={loadMoreEscrowOrders}
-              hasMore={hasNextEscrowOrders}
-              loader={
-                <>
-                  <Skeleton variant="text" />
-                  <Skeleton variant="text" />
-                </>
-              }
-              scrollableTarget="scrollableDiv"
-            >
-              {escrowOrdersData.map(item => {
-                return <OrderDetailInfo item={item.data as EscrowOrderQueryItem} key={item.id} />;
-              })}
-            </InfiniteScroll>
-          ) : (
-            <Typography style={{ textAlign: 'center', marginTop: '2rem' }}>
-              No {orderStatus?.toLowerCase()} orders here
-            </Typography>
-          )}
-        </div>
+        <Tabs value={value} onChange={handleChange} indicatorColor="secondary" textColor="inherit" variant="fullWidth">
+          <Tab
+            label={TabType.PENDING}
+            value={TabType.PENDING}
+            id={`full-width-tab-${TabType.PENDING}`}
+            aria-controls={`full-width-tabpanel-${TabType.PENDING}`}
+          />
+          <Tab
+            label={TabType.ESCROWED}
+            value={TabType.ESCROWED}
+            id={`full-width-tab-${TabType.ESCROWED}`}
+            aria-controls={`full-width-tabpanel-${TabType.ESCROWED}`}
+          />
+          <Tab
+            label={TabType.ARCHIVED}
+            value={TabType.ARCHIVED}
+            id={`full-width-tab-${TabType.ARCHIVED}`}
+            aria-controls={`full-width-tabpanel-${TabType.ARCHIVED}`}
+          />
+        </Tabs>
+        <SwipeableViews index={getTabIndex(value)} onChangeIndex={handleChangeIndex}>
+          <TabPanel value={getTabIndex(value)} index={0}>
+            {ListItem()}
+          </TabPanel>
+          <TabPanel value={getTabIndex(value)} index={1}>
+            {ListItem()}
+          </TabPanel>
+          <TabPanel value={getTabIndex(value)} index={2}>
+            <div className="list-item">{ListItem()}</div>
+          </TabPanel>
+        </SwipeableViews>
       </>
     );
   };

--- a/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
@@ -1040,7 +1040,7 @@ const OrderDetail = () => {
         <ConfirmCancelModal
           isOpen={openCancelModal}
           returnAction={value => handleBuyerReturnEscrow(value)}
-          onDissmissModal={value => setOpenCancelModal(value)}
+          onDismissModal={value => setOpenCancelModal(value)}
           isBuyerDeposit={currentData?.escrowOrder.buyerDepositTx ? true : false}
           disputeFee={calDisputeFee}
         />
@@ -1049,7 +1049,7 @@ const OrderDetail = () => {
           isOpen={openReleaseModal}
           disputeFee={calDisputeFee}
           returnAction={value => handleSellerReleaseEscrow(value)}
-          onDissmissModal={value => setOpenReleaseModal(value)}
+          onDismissModal={value => setOpenReleaseModal(value)}
         />
 
         <Stack zIndex={999}>

--- a/apps/telegram-ecash-escrow/src/app/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/page.tsx
@@ -119,23 +119,6 @@ export default function Home() {
     window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
   };
 
-  // useEffect(() => {
-  //   (async () => {
-  //     const country = await axiosClient
-  //       .get(`/api/countries/ipaddr`)
-  //       .then(result => {
-  //         return result.data;
-  //       })
-  //       .catch(({ response }) => {
-  //         console.log(response?.data.message);
-  //       });
-
-  //     if (country && country === 'US') {
-  //       return router.push('/not-available');
-  //     }
-  //   })();
-  // }, []);
-
   //reset flag for new-post when reload
   useEffect(() => {
     dispatch(setNewPostAvailable(false));
@@ -182,7 +165,7 @@ export default function Home() {
           <Section>
             <div className="content-wrap">
               <Typography className="title-offer" variant="body1">
-                Offer Watchlist
+                Offers
               </Typography>
             </div>
             <div className="offer-list">

--- a/apps/telegram-ecash-escrow/src/app/settings/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/settings/page.tsx
@@ -246,7 +246,7 @@ export default function Setting() {
       </ContainerSetting>
       <ConfirmSignoutModal
         isOpen={openSignoutModal}
-        onDissmissModal={value => setOpenSignoutModal(value)}
+        onDismissModal={value => setOpenSignoutModal(value)}
         signout={isSignout => {
           if (isSignout) {
             handleSignOut();

--- a/apps/telegram-ecash-escrow/src/app/settings/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/settings/page.tsx
@@ -1,11 +1,10 @@
 'use client';
+import ConfirmSignoutModal from '@/src/components/Settings/ConfirmSignoutModal';
 import CustomToast from '@/src/components/Toast/CustomToast';
 import MobileLayout from '@/src/components/layout/MobileLayout';
 import {
   getCurrentThemes,
   getIsSystemThemes,
-  getSelectedAccount,
-  getSelectedWalletPath,
   getWalletMnemonic,
   removeAllWallets,
   setCurrentThemes,
@@ -17,7 +16,7 @@ import { CheckCircleOutline } from '@mui/icons-material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Accordion, AccordionDetails, AccordionSummary, Alert, Button, NativeSelect, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { signOut, useSession } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
 import { useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { THEMES_TYPE } from 'src/store/constants';
@@ -73,15 +72,13 @@ const ContainerSetting = styled('div')(({ theme }) => ({
 }));
 
 export default function Setting() {
-  const { data: sessionData } = useSession();
   const dispatch = useLixiSliceDispatch();
-  const selectedWalletPath = useLixiSliceSelector(getSelectedWalletPath);
   const selectedMnemonic = useLixiSliceSelector(getWalletMnemonic);
-  const selectedAccount = useLixiSliceSelector(getSelectedAccount);
   const isSystemTheme = useLixiSliceSelector(getIsSystemThemes);
   const currentTheme = useLixiSliceSelector(getCurrentThemes);
 
   const [openToastCopySuccess, setOpenToastCopySuccess] = useState(false);
+  const [openSignoutModal, setOpenSignoutModal] = useState(false);
 
   const themeOptions = [
     {
@@ -124,7 +121,7 @@ export default function Setting() {
       <ContainerSetting>
         <div className="setting-info">
           <Typography variant="h4" className="title">
-            Setting
+            Settings
           </Typography>
         </div>
         {/*TODO: Verify account*/}
@@ -196,7 +193,7 @@ export default function Setting() {
                     fontWeight: 'bold',
                     color: '#fff'
                   }}
-                  onClick={() => handleSignOut()}
+                  onClick={() => setOpenSignoutModal(true)}
                 >
                   Sign Out
                 </Button>
@@ -206,7 +203,7 @@ export default function Setting() {
 
           <div className="setting-item">
             <Typography variant="subtitle1" className="title">
-              Themes
+              Theme
             </Typography>
             <NativeSelect
               fullWidth
@@ -247,6 +244,17 @@ export default function Setting() {
           type="info"
         />
       </ContainerSetting>
+      <ConfirmSignoutModal
+        isOpen={openSignoutModal}
+        onDissmissModal={value => setOpenSignoutModal(value)}
+        signout={isSignout => {
+          if (isSignout) {
+            handleSignOut();
+          } else {
+            setOpenSignoutModal(false);
+          }
+        }}
+      />
     </MobileLayout>
   );
 }

--- a/apps/telegram-ecash-escrow/src/components/Action/ConfirmCancelModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Action/ConfirmCancelModal.tsx
@@ -22,7 +22,7 @@ import React, { useState } from 'react';
 
 interface ConfirmCancelModalProps {
   isOpen: boolean;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   onConfirmClick?: () => void;
   returnAction: (value: boolean) => void;
   isBuyerDeposit: boolean;
@@ -114,10 +114,10 @@ const ConfirmCancelModal: React.FC<ConfirmCancelModalProps> = props => {
       <StyledDialog
         // fullScreen={fullScreen}
         open={props.isOpen}
-        onClose={() => props.onDissmissModal!(false)}
+        onClose={() => props.onDismissModal!(false)}
         TransitionComponent={Transition}
       >
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogTitle paddingTop="0px !important">Confirmation</DialogTitle>
@@ -162,7 +162,7 @@ const ConfirmCancelModal: React.FC<ConfirmCancelModalProps> = props => {
             variant="contained"
             onClick={() => {
               props.returnAction(optionDonate);
-              props.onDissmissModal!(false);
+              props.onDismissModal!(false);
             }}
             autoFocus
           >

--- a/apps/telegram-ecash-escrow/src/components/Action/ConfirmReleaseModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Action/ConfirmReleaseModal.tsx
@@ -84,7 +84,7 @@ const ActionStatusRelease = styled('div')(({ theme }) => ({
 interface ConfirmReleaseModalProps {
   isOpen: boolean;
   disputeFee: number;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   onConfirmClick?: () => void;
   returnAction: (value: boolean) => void;
 }
@@ -116,13 +116,13 @@ const ConfirmReleaseModal: React.FC<ConfirmReleaseModalProps> = (props: ConfirmR
 
   const handleReleaseConfirm = data => {
     props.returnAction(optionDonate);
-    props.onDissmissModal!(false);
+    props.onDismissModal!(false);
   };
 
   return (
     <React.Fragment>
-      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDismissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogTitle paddingTop="0px !important">Confirmation</DialogTitle>

--- a/apps/telegram-ecash-escrow/src/components/Auth/ConfirmCreateNewAccountModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Auth/ConfirmCreateNewAccountModal.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { styled } from '@mui/material/styles';
+
+import { ChevronLeft } from '@mui/icons-material';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Slide,
+  Typography
+} from '@mui/material';
+import { TransitionProps } from '@mui/material/transitions';
+import React from 'react';
+
+interface ConfirmCreateNewAccountModalProps {
+  isOpen: boolean;
+  isLoading: boolean;
+  onDissmissModal?: (value: boolean) => void;
+  createAccount?: (isDeposit: boolean) => void;
+}
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+  '.MuiPaper-root': {
+    background: theme.palette.background.default,
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    width: '500px',
+    maxHeight: '100%',
+    padding: '16px',
+    margin: '0',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%'
+    }
+  },
+
+  '.MuiIconButton-root': {
+    width: 'fit-content',
+    svg: {
+      fontSize: '32px'
+    }
+  },
+
+  '.MuiDialogTitle-root': {
+    padding: '0 16px',
+    paddingTop: '16px',
+    fontSize: '26px',
+    textAlign: 'center'
+  },
+
+  '.MuiDialogContent-root': {
+    padding: '0'
+  },
+
+  '.MuiDialogActions-root': {
+    justifyContent: 'space-evenly',
+
+    button: {
+      textTransform: 'none',
+      width: '100%',
+      '&.confirm-btn': {
+        color: theme.palette.common.white
+      }
+    }
+  },
+
+  '.back-btn': {
+    padding: '0',
+    position: 'absolute',
+    left: '8px',
+    top: '20px',
+    borderRadius: '12px',
+    svg: {
+      fontSize: '32px'
+    }
+  }
+}));
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & {
+    children: React.ReactElement;
+  },
+  ref: React.Ref<unknown>
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
+
+const ConfirmCreateNewAccountModal: React.FC<ConfirmCreateNewAccountModalProps> = props => {
+  return (
+    <React.Fragment>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+          <ChevronLeft />
+        </IconButton>
+        <DialogTitle paddingTop="0px !important">Confirm create new account</DialogTitle>
+        <DialogContent>
+          <Typography variant="body1" sx={{ marginTop: '10px' }}>
+            Create a new account with a new seed phrase. This will overwrite the existing account. Are you sure want to
+            continue?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            className="confirm-btn"
+            variant="contained"
+            color="warning"
+            onClick={() => {
+              props.createAccount!(false);
+            }}
+            disabled={props.isLoading}
+            autoFocus
+          >
+            Not create
+          </Button>
+          <Button
+            className="confirm-btn"
+            variant="contained"
+            color="success"
+            onClick={() => {
+              props.createAccount!(true);
+            }}
+            disabled={props.isLoading}
+            autoFocus
+          >
+            Create with new seed
+          </Button>
+        </DialogActions>
+      </StyledDialog>
+    </React.Fragment>
+  );
+};
+
+export default ConfirmCreateNewAccountModal;

--- a/apps/telegram-ecash-escrow/src/components/Auth/ConfirmCreateNewAccountModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Auth/ConfirmCreateNewAccountModal.tsx
@@ -19,8 +19,8 @@ import React from 'react';
 interface ConfirmCreateNewAccountModalProps {
   isOpen: boolean;
   isLoading: boolean;
-  onDissmissModal?: (value: boolean) => void;
-  createAccount?: (isDeposit: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
+  createAccount?: (isCreateAccount: boolean) => void;
 }
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
@@ -91,8 +91,8 @@ const Transition = React.forwardRef(function Transition(
 const ConfirmCreateNewAccountModal: React.FC<ConfirmCreateNewAccountModalProps> = props => {
   return (
     <React.Fragment>
-      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDismissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogTitle paddingTop="0px !important">Confirm create new account</DialogTitle>

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/ConfirmOfferTypeModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/ConfirmOfferTypeModal.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 interface ConfirmOfferTypeModalProps {
   isOpen: boolean;
   isLoading: boolean;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   createOffer?: (isHidden: boolean) => void;
 }
 
@@ -91,8 +91,8 @@ const Transition = React.forwardRef(function Transition(
 const ConfirmOfferTypeModal: React.FC<ConfirmOfferTypeModalProps> = props => {
   return (
     <React.Fragment>
-      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDismissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogTitle paddingTop="0px !important">Confirm Offer Type</DialogTitle>

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -1287,7 +1287,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
       </Portal>
       <FilterListModal
         isOpen={openCountryList}
-        onDissmissModal={value => setOpenCountryList(value)}
+        onDismissModal={value => setOpenCountryList(value)}
         setSelectedItem={async value => {
           setValue('country', value);
           clearErrors('country');
@@ -1301,7 +1301,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
         isOpen={openStateList}
         listItems={listStates}
         propertyToSearch="adminNameAscii"
-        onDissmissModal={value => setOpenStateList(value)}
+        onDismissModal={value => setOpenStateList(value)}
         setSelectedItem={async value => {
           setValue('state', value);
           clearErrors('state');
@@ -1314,7 +1314,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
         isOpen={openCityList}
         listItems={listCities}
         propertyToSearch="cityAscii"
-        onDissmissModal={value => setOpenCityList(value)}
+        onDismissModal={value => setOpenCityList(value)}
         setSelectedItem={value => {
           setValue('city', value);
           clearErrors('city');
@@ -1324,7 +1324,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
       <ConfirmOfferTypeModal
         isOpen={openConfirmType}
         isLoading={loading}
-        onDissmissModal={value => setOpenConfirmType(value)}
+        onDismissModal={value => setOpenConfirmType(value)}
         createOffer={isHidden => {
           handleSubmit(data => {
             handleCreateOffer(data, isHidden);

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -31,10 +31,12 @@ import {
   IconButton,
   InputAdornment,
   InputLabel,
+  MenuItem,
   NativeSelect,
   Portal,
   Radio,
   RadioGroup,
+  Select,
   Slide,
   TextField,
   Typography,
@@ -699,7 +701,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
               />
             </Grid>
 
-            {(coinValue?.includes(COIN_OTHERS) || coinValue?.includes(COIN_USD_STABLECOIN_TICKER)) && (
+            {coinValue?.includes(COIN_OTHERS) && (
               <Grid item xs={4}>
                 <Controller
                   name="coinOthers"
@@ -729,6 +731,35 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
                           maxLength: 12
                         }}
                       />
+                    </FormControl>
+                  )}
+                />
+              </Grid>
+            )}
+
+            {coinValue?.includes(COIN_USD_STABLECOIN_TICKER) && (
+              <Grid item xs={4}>
+                <Controller
+                  name="coinOthers"
+                  control={control}
+                  render={({ field: { onChange, onBlur, value, name, ref } }) => (
+                    <FormControl fullWidth={true} variant="standard" error={errors.coinOthers && true}>
+                      <InputLabel id="coinOthers-label">Ticker</InputLabel>
+                      <Select
+                        className="form-input"
+                        onChange={onChange}
+                        onBlur={onBlur}
+                        value={value}
+                        name={name}
+                        inputRef={ref}
+                        id="coinOthers"
+                        labelId="coinOthers-label"
+                        label="Ticker"
+                      >
+                        <MenuItem value="USDT">USDT</MenuItem>
+                        <MenuItem value="USDC">USDC</MenuItem>
+                      </Select>
+                      {errors.coinOthers && <FormHelperText>{errors.coinOthers?.message as string}</FormHelperText>}
                     </FormControl>
                   )}
                 />

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
@@ -58,7 +58,8 @@ const OrderDetailWrap = styled('div')(({ theme }) => ({
   '.wrap-order-id': {
     display: 'flex',
     alignItems: 'center',
-    gap: '5px'
+    gap: '5px',
+    cursor: 'pointer'
   },
 
   '.order-id': {
@@ -66,6 +67,10 @@ const OrderDetailWrap = styled('div')(({ theme }) => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'
+  },
+
+  button: {
+    pointerEvents: 'none'
   }
 }));
 
@@ -232,7 +237,17 @@ const OrderDetailInfo = ({
       }
     }
 
-    return order?.escrowOrderStatus?.toLowerCase()?.replace(/^./, char => char.toUpperCase());
+    const capitalizeStatus = order?.escrowOrderStatus?.toLowerCase()?.replace(/^./, char => char.toUpperCase());
+    let status = capitalizeStatus;
+    if (
+      order?.escrowOrderStatus === EscrowOrderStatus.Escrow ||
+      order?.escrowOrderStatus === EscrowOrderStatus.Cancel ||
+      order?.escrowOrderStatus === EscrowOrderStatus.Complete
+    ) {
+      status = capitalizeStatus + 'ed';
+    }
+
+    return status;
   };
 
   //get rate data
@@ -254,9 +269,9 @@ const OrderDetailInfo = ({
   }, [rateData]);
 
   return (
-    <OrderDetailWrap onClick={() => router.push(`/order-detail?id=${order.id}`)}>
+    <OrderDetailWrap>
       <Typography className="order-first-line" variant="body1" component="div">
-        <div className="wrap-order-id">
+        <div className="wrap-order-id" onClick={() => router.push(`/order-detail?id=${order.id}`)}>
           <span className="prefix">No: </span>
           <span className="order-id">{order.id}</span>
         </div>

--- a/apps/telegram-ecash-escrow/src/components/FilterList/FilterListLocationModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/FilterList/FilterListLocationModal.tsx
@@ -22,7 +22,7 @@ interface FilterListLocationModalProps {
   isOpen: boolean;
   listItems: Location[];
   propertyToSearch: 'adminNameAscii' | 'cityAscii';
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   setSelectedItem?: (value: any) => void;
 }
 
@@ -72,7 +72,7 @@ const Transition = React.forwardRef(function Transition(
 });
 
 const FilterListLocationModal: React.FC<FilterListLocationModalProps> = props => {
-  const { isOpen, listItems, propertyToSearch, onDissmissModal, setSelectedItem } = props;
+  const { isOpen, listItems, propertyToSearch, onDismissModal, setSelectedItem } = props;
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -80,7 +80,7 @@ const FilterListLocationModal: React.FC<FilterListLocationModalProps> = props =>
 
   const handleSelect = value => {
     setSelectedItem(value);
-    onDissmissModal(false);
+    onDismissModal(false);
   };
 
   const filteredOptions = listItems.filter(option =>
@@ -91,10 +91,10 @@ const FilterListLocationModal: React.FC<FilterListLocationModalProps> = props =>
       <StyledDialog
         fullScreen={fullScreen}
         open={isOpen}
-        onClose={() => props.onDissmissModal!(false)}
+        onClose={() => props.onDismissModal!(false)}
         TransitionComponent={Transition}
       >
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogContent>

--- a/apps/telegram-ecash-escrow/src/components/FilterList/FilterListModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/FilterList/FilterListModal.tsx
@@ -19,7 +19,7 @@ import React, { useState } from 'react';
 interface FilterListModalProps {
   isOpen: boolean;
   listItems: any;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   setSelectedItem?: (value: any) => void;
 }
 
@@ -70,7 +70,7 @@ const Transition = React.forwardRef(function Transition(
 });
 
 const FilterListModal: React.FC<FilterListModalProps> = props => {
-  const { isOpen, listItems, onDissmissModal, setSelectedItem } = props;
+  const { isOpen, listItems, onDismissModal, setSelectedItem } = props;
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -78,7 +78,7 @@ const FilterListModal: React.FC<FilterListModalProps> = props => {
 
   const handleSelect = value => {
     setSelectedItem(value);
-    onDissmissModal(false);
+    onDismissModal(false);
   };
 
   const filteredOptions = listItems.filter(option => option?.name?.toLowerCase().includes(searchTerm.toLowerCase()));
@@ -87,10 +87,10 @@ const FilterListModal: React.FC<FilterListModalProps> = props => {
       <StyledDialog
         fullScreen={fullScreen}
         open={isOpen}
-        onClose={() => props.onDissmissModal!(false)}
+        onClose={() => props.onDismissModal!(false)}
         TransitionComponent={Transition}
       >
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogContent>

--- a/apps/telegram-ecash-escrow/src/components/FilterList/QueryListLocationModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/FilterList/QueryListLocationModal.tsx
@@ -21,7 +21,7 @@ interface QueryListLocationModalProps {
   listItems: any;
   loading?: boolean;
   handleChange: (value: any) => void;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   setSelectedItem?: (value: any) => void;
 }
 
@@ -72,7 +72,7 @@ const Transition = React.forwardRef(function Transition(
 });
 
 const QueryListLocationModal: React.FC<QueryListLocationModalProps> = props => {
-  const { isOpen, listItems, loading, onDissmissModal, setSelectedItem, handleChange } = props;
+  const { isOpen, listItems, loading, onDismissModal, setSelectedItem, handleChange } = props;
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -80,7 +80,7 @@ const QueryListLocationModal: React.FC<QueryListLocationModalProps> = props => {
 
   const handleSelect = value => {
     setSelectedItem(value);
-    onDissmissModal(false);
+    onDismissModal(false);
   };
 
   return (
@@ -88,10 +88,10 @@ const QueryListLocationModal: React.FC<QueryListLocationModalProps> = props => {
       <StyledDialog
         fullScreen={fullScreen}
         open={isOpen}
-        onClose={() => props.onDissmissModal!(false)}
+        onClose={() => props.onDismissModal!(false)}
         TransitionComponent={Transition}
       >
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogContent>

--- a/apps/telegram-ecash-escrow/src/components/FilterOfferModal/FilterOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/FilterOfferModal/FilterOfferModal.tsx
@@ -42,7 +42,7 @@ import FilterListModal from '../FilterList/FilterListModal';
 
 interface FilterOfferModalProps {
   isOpen: boolean;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   onConfirmClick?: () => void;
 }
 
@@ -306,7 +306,7 @@ const FilterOfferModal: React.FC<FilterOfferModalProps> = props => {
     }
 
     dispatch(saveOfferFilterConfig(offerFilterInput));
-    props.onDissmissModal!(false);
+    props.onDismissModal!(false);
   };
 
   const handleReset = () => {
@@ -389,10 +389,10 @@ const FilterOfferModal: React.FC<FilterOfferModalProps> = props => {
     <StyledDialog
       fullScreen={fullScreen}
       open={props.isOpen}
-      onClose={() => props.onDissmissModal!(false)}
+      onClose={() => props.onDismissModal!(false)}
       TransitionComponent={Transition}
     >
-      <IconButton className="close-btn" onClick={() => props.onDissmissModal!(false)}>
+      <IconButton className="close-btn" onClick={() => props.onDismissModal!(false)}>
         <CloseOutlined />
       </IconButton>
       <DialogTitle>Filter</DialogTitle>
@@ -736,7 +736,7 @@ const FilterOfferModal: React.FC<FilterOfferModalProps> = props => {
           autoFocus
           onClick={() => {
             handleReset();
-            props.onDissmissModal!(false);
+            props.onDismissModal!(false);
           }}
         >
           Reset
@@ -747,7 +747,7 @@ const FilterOfferModal: React.FC<FilterOfferModalProps> = props => {
       </DialogActions>
       <FilterListModal
         isOpen={openCountryList}
-        onDissmissModal={value => setOpenCountryList(value)}
+        onDismissModal={value => setOpenCountryList(value)}
         setSelectedItem={async value => {
           setValue('country', value);
           clearErrors('country');
@@ -761,7 +761,7 @@ const FilterOfferModal: React.FC<FilterOfferModalProps> = props => {
         isOpen={openStateList}
         listItems={listStates}
         propertyToSearch="adminNameAscii"
-        onDissmissModal={value => setOpenStateList(value)}
+        onDismissModal={value => setOpenStateList(value)}
         setSelectedItem={async value => {
           setValue('state', value);
           clearErrors('state');
@@ -774,7 +774,7 @@ const FilterOfferModal: React.FC<FilterOfferModalProps> = props => {
         isOpen={openCityList}
         listItems={listCities}
         propertyToSearch="cityAscii"
-        onDissmissModal={value => setOpenCityList(value)}
+        onDismissModal={value => setOpenCityList(value)}
         setSelectedItem={value => {
           setValue('city', value);
           clearErrors('city');

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/ConfirmDepositModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/ConfirmDepositModal.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { styled } from '@mui/material/styles';
+
+import { COIN } from '@bcpros/lixi-models';
+import { ChevronLeft } from '@mui/icons-material';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Slide,
+  Typography
+} from '@mui/material';
+import { TransitionProps } from '@mui/material/transitions';
+import React from 'react';
+
+interface ConfirmDepositModalProps {
+  isOpen: boolean;
+  depositSecurity: number;
+  isLoading: boolean;
+  onDissmissModal?: (value: boolean) => void;
+  depositFee?: (isDeposit: boolean) => void;
+}
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+  '.MuiPaper-root': {
+    background: theme.palette.background.default,
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    width: '500px',
+    maxHeight: '100%',
+    padding: '16px',
+    margin: '0',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%'
+    }
+  },
+
+  '.MuiIconButton-root': {
+    width: 'fit-content',
+    svg: {
+      fontSize: '32px'
+    }
+  },
+
+  '.MuiDialogTitle-root': {
+    padding: '0 16px',
+    paddingTop: '16px',
+    fontSize: '26px',
+    textAlign: 'center'
+  },
+
+  '.MuiDialogContent-root': {
+    padding: '0'
+  },
+
+  '.MuiDialogActions-root': {
+    justifyContent: 'space-evenly',
+
+    button: {
+      textTransform: 'none',
+      width: '100%',
+      '&.confirm-btn': {
+        color: theme.palette.common.white
+      }
+    }
+  },
+
+  '.back-btn': {
+    padding: '0',
+    position: 'absolute',
+    left: '8px',
+    top: '20px',
+    borderRadius: '12px',
+    svg: {
+      fontSize: '32px'
+    }
+  }
+}));
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & {
+    children: React.ReactElement;
+  },
+  ref: React.Ref<unknown>
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
+
+const ConfirmDepositModal: React.FC<ConfirmDepositModalProps> = props => {
+  return (
+    <React.Fragment>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+          <ChevronLeft />
+        </IconButton>
+        <DialogTitle paddingTop="0px !important">Confirm Security Deposit</DialogTitle>
+        <DialogContent>
+          <Typography variant="subtitle2" sx={{ marginTop: '10px' }}>
+            * Deposit a security deposit to have a higher chance of being accepted. The security deposit will be
+            returned if there is no dispute.
+          </Typography>
+          <Typography variant="body1" sx={{ marginTop: '10px', fontWeight: 'bold' }}>
+            Security deposit (1%): {props.depositSecurity.toLocaleString('de-DE')} {COIN.XEC}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            className="confirm-btn"
+            variant="contained"
+            color="warning"
+            onClick={() => {
+              props.depositFee!(false);
+            }}
+            disabled={props.isLoading}
+            autoFocus
+          >
+            Not deposit
+          </Button>
+          <Button
+            className="confirm-btn"
+            variant="contained"
+            color="success"
+            onClick={() => {
+              props.depositFee!(true);
+            }}
+            disabled={props.isLoading}
+            autoFocus
+          >
+            Deposit
+          </Button>
+        </DialogActions>
+      </StyledDialog>
+    </React.Fragment>
+  );
+};
+
+export default ConfirmDepositModal;

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/ConfirmDepositModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/ConfirmDepositModal.tsx
@@ -21,7 +21,7 @@ interface ConfirmDepositModalProps {
   isOpen: boolean;
   depositSecurity: number;
   isLoading: boolean;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   depositFee?: (isDeposit: boolean) => void;
 }
 
@@ -93,8 +93,8 @@ const Transition = React.forwardRef(function Transition(
 const ConfirmDepositModal: React.FC<ConfirmDepositModalProps> = props => {
   return (
     <React.Fragment>
-      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDismissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogTitle paddingTop="0px !important">Confirm Security Deposit</DialogTitle>

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
@@ -981,7 +981,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
         isOpen={openConfirmDeposit}
         depositSecurity={calDisputeFee}
         isLoading={loading}
-        onDissmissModal={value => setOpenConfirmDeposit(value)}
+        onDismissModal={value => setOpenConfirmDeposit(value)}
         depositFee={isDeposit => {
           handleSubmit(data => {
             handleCreateEscrowOrder(data, isDeposit);

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
@@ -18,7 +18,6 @@ import {
   fiatCurrencyApi,
   getModals,
   getSelectedWalletPath,
-  parseCashAddressToPrefix,
   showToast,
   useSliceDispatch as useLixiSliceDispatch,
   useSliceSelector as useLixiSliceSelector
@@ -27,7 +26,6 @@ import { ChevronLeft } from '@mui/icons-material';
 import {
   Box,
   Button,
-  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
@@ -56,8 +54,8 @@ import { useRouter } from 'next/navigation';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { FormControlWithNativeSelect } from '../FilterOfferModal/FilterOfferModal';
-import QRCode from '../QRcode/QRcode';
 import CustomToast from '../Toast/CustomToast';
+import ConfirmDepositModal from './ConfirmDepositModal';
 
 interface PlaceAnOrderModalProps {
   isOpen: boolean;
@@ -284,6 +282,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
   const [escrowScript, setEscrowScript] = useState<Escrow>(null);
   const [nonce, setNonce] = useState<string>(null);
   const [confirm, setConfirm] = useState(false);
+  const [openConfirmDeposit, setOpenConfirmDeposit] = useState(false);
   const selectedWalletPath = useLixiSliceSelector(getSelectedWalletPath);
 
   const { useCreateEscrowOrderMutation, useGetModeratorAccountQuery, useGetRandomArbitratorAccountQuery } =
@@ -311,14 +310,12 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
   const {
     handleSubmit,
     formState: { errors },
-    // setError: setErrorForm,
     clearErrors,
     control,
     trigger,
     watch
   } = useForm();
   const amountValue = watch('amount');
-  const isBuyerDeposit = watch('isDepositFee');
 
   const calEscrowScript = () => {
     const sellerPk = isBuyOffer ? fromHex(selectedWalletPath?.publicKey ?? '') : fromHex(post.account.publicKey);
@@ -339,7 +336,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
     setNonce(nonce);
   };
 
-  const handleCreateEscrowOrder = async data => {
+  const handleCreateEscrowOrder = async (data, isDepositFee) => {
     setLoading(true);
     if (moderatorIsError || arbitratorIsError) {
       setArbiDataError(true);
@@ -356,7 +353,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
       accountNumberApp: post.postOffer?.paymentApp ? data?.accountNumber : null
     };
 
-    const { amount, message, isDepositFee }: { amount: string; message: string; isDepositFee: boolean } = data;
+    const { amount, message }: { amount: string; message: string } = data;
     const offerAccountId = post.accountId;
     const moderatorId = moderatorCurrentData.getModeratorAccount.id;
     const arbitratorId = arbitratorCurrentData.getRandomArbitratorAccount.id;
@@ -449,22 +446,6 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
 
   const checkBuyerEnoughFund = () => {
     return totalValidAmount > calDisputeFee;
-  };
-
-  const InfoEscrow = () => {
-    const fee1Percent = calDisputeFee;
-    const totalBalanceFormat = totalValidAmount.toLocaleString('de-DE');
-
-    return (
-      <div>
-        <Typography component="p" variant="body1">
-          Your wallet: {totalBalanceFormat} {COIN.XEC}
-        </Typography>
-        <Typography component="p" variant="body1">
-          Security deposit (1%): {fee1Percent.toLocaleString('de-DE')} {COIN.XEC}
-        </Typography>
-      </div>
-    );
   };
 
   const InfoPaymentDetail = () => {
@@ -692,6 +673,19 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
     );
   };
 
+  const handleCreateOrderBeforeConfirm = async () => {
+    const isValid = await trigger();
+    if (!isValid) return;
+
+    if (checkBuyerEnoughFund()) {
+      setOpenConfirmDeposit(true);
+    } else {
+      handleSubmit(data => {
+        handleCreateEscrowOrder(data, false);
+      })();
+    }
+  };
+
   // // Handle browser history to manage the modal
   useEffect(() => {
     // Function to handle the popstate event (when back button is clicked)
@@ -915,39 +909,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
                 <Typography color="error">{errors?.paymentMethod?.message as string}</Typography>
               )}
             </RadioGroup>
-            {isBuyOffer ? (
-              InfoPaymentDetail()
-            ) : (
-              <div className="disclaim-wrap">
-                <Typography className="title" variant="body2">
-                  * Deposit a security deposit to have a higher chance of being accepted. The security deposit will be
-                  returned if there is no dispute.
-                </Typography>
-                <Controller
-                  name="isDepositFee"
-                  control={control}
-                  defaultValue={false}
-                  render={({ field: { onChange, onBlur, value, ref } }) => (
-                    <FormControlLabel
-                      control={<Checkbox onChange={onChange} onBlur={onBlur} checked={value} inputRef={ref} />}
-                      label={`I want to deposit security deposit (1%): ${calDisputeFee} XEC`}
-                    />
-                  )}
-                />
-                {isBuyerDeposit && (
-                  <div>
-                    {InfoEscrow()}
-                    {!checkBuyerEnoughFund() && (
-                      <QRCode
-                        address={parseCashAddressToPrefix(COIN.XEC, selectedWalletPath?.cashAddress)}
-                        amount={calDisputeFee}
-                        width="60%"
-                      />
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
+            {isBuyOffer && InfoPaymentDetail()}
           </PlaceAnOrderWrap>
         </DialogContent>
         <DialogActions>
@@ -957,13 +919,13 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
             variant="contained"
             onClick={() => {
               if (post?.account?.telegramUsername.startsWith('@')) {
-                handleSubmit(handleCreateEscrowOrder)(); //need parenthesis to call handleSubmit
+                handleCreateOrderBeforeConfirm();
               } else {
                 setConfirm(true);
               }
             }}
             autoFocus
-            disabled={(isBuyerDeposit && !checkBuyerEnoughFund()) || loading}
+            disabled={loading}
           >
             Create
           </Button>
@@ -1001,12 +963,31 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
             <Button variant="contained" fullWidth onClick={() => setConfirm(false)}>
               Cancel
             </Button>
-            <Button variant="contained" fullWidth color="warning" onClick={handleSubmit(handleCreateEscrowOrder)}>
+            <Button
+              variant="contained"
+              fullWidth
+              color="warning"
+              onClick={() => {
+                handleCreateOrderBeforeConfirm();
+              }}
+            >
               Continue
             </Button>
           </div>
         </StyledBox>
       </Modal>
+
+      <ConfirmDepositModal
+        isOpen={openConfirmDeposit}
+        depositSecurity={calDisputeFee}
+        isLoading={loading}
+        onDissmissModal={value => setOpenConfirmDeposit(value)}
+        depositFee={isDeposit => {
+          handleSubmit(data => {
+            handleCreateEscrowOrder(data, isDeposit);
+          })();
+        }}
+      />
     </React.Fragment>
   );
 };

--- a/apps/telegram-ecash-escrow/src/components/QRcode/ScanQRcode.tsx
+++ b/apps/telegram-ecash-escrow/src/components/QRcode/ScanQRcode.tsx
@@ -9,19 +9,19 @@ const StyledDialog = styled(Dialog)``;
 
 interface ScanQRcodeProps {
   isOpen: boolean;
-  onDissmissModal: (value: boolean) => void;
+  onDismissModal: (value: boolean) => void;
   setAddress: (addr: string) => void;
 }
 
-const ScanQRcode: React.FC<ScanQRcodeProps> = ({ isOpen, onDissmissModal, setAddress }) => {
+const ScanQRcode: React.FC<ScanQRcodeProps> = ({ isOpen, onDismissModal, setAddress }) => {
   return (
     <>
-      <StyledDialog open={isOpen} onClose={() => onDissmissModal(false)}>
+      <StyledDialog open={isOpen} onClose={() => onDismissModal(false)}>
         <div>
           <Scanner
             onScan={result => {
               setAddress(result[0]?.rawValue ?? '');
-              onDissmissModal(false);
+              onDismissModal(false);
             }}
             onError={err => {
               console.log(err);

--- a/apps/telegram-ecash-escrow/src/components/ReleaseDisputeModal/ReleaseDisputeModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/ReleaseDisputeModal/ReleaseDisputeModal.tsx
@@ -20,7 +20,7 @@ import DisputeDetailInfo from '../DisputeDetailInfo/DisputeDetailInfo';
 
 interface ReleaseDisputeModalProps {
   isOpen: boolean;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   onConfirmClick?: () => void;
 }
 
@@ -115,10 +115,10 @@ const ReleaseDisputeModal: React.FC<ReleaseDisputeModalProps> = props => {
     <StyledDialog
       fullScreen={fullScreen}
       open={props.isOpen}
-      onClose={() => props.onDissmissModal!(false)}
+      onClose={() => props.onDismissModal!(false)}
       TransitionComponent={Transition}
     >
-      <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+      <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
         <ChevronLeft />
       </IconButton>
       <DialogTitle>Resolve Dispute</DialogTitle>
@@ -143,7 +143,7 @@ const ReleaseDisputeModal: React.FC<ReleaseDisputeModalProps> = props => {
           color="info"
           variant="contained"
           onClick={() => {
-            props.onDissmissModal!(false);
+            props.onDismissModal!(false);
           }}
         >
           Resolve

--- a/apps/telegram-ecash-escrow/src/components/ResolveDisputeModal/ResolveDisputeModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/ResolveDisputeModal/ResolveDisputeModal.tsx
@@ -22,7 +22,7 @@ import DisputeDetailInfo from '../DisputeDetailInfo/DisputeDetailInfo';
 
 interface PlaceAnOrderModalProps {
   isOpen: boolean;
-  onDissmissModal?: (value: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
   onConfirmClick?: () => void;
 }
 
@@ -185,10 +185,10 @@ const ResolveDisputeModal: React.FC<PlaceAnOrderModalProps> = props => {
       <StyledDialog
         fullScreen={fullScreen}
         open={props.isOpen}
-        onClose={() => props.onDissmissModal!(false)}
+        onClose={() => props.onDismissModal!(false)}
         TransitionComponent={Transition}
       >
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogTitle>Resolve Dispute</DialogTitle>

--- a/apps/telegram-ecash-escrow/src/components/Send/send.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Send/send.tsx
@@ -227,7 +227,7 @@ const SendComponent: React.FC<SendComponentProps> = props => {
       </Button>
       <ScanQRcode
         isOpen={openScan}
-        onDissmissModal={value => {
+        onDismissModal={value => {
           setOpenScan(value);
         }}
         setAddress={value => {

--- a/apps/telegram-ecash-escrow/src/components/Settings/ConfirmSignoutModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Settings/ConfirmSignoutModal.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { styled } from '@mui/material/styles';
+
+import { ChevronLeft } from '@mui/icons-material';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Slide,
+  Typography
+} from '@mui/material';
+import { TransitionProps } from '@mui/material/transitions';
+import React from 'react';
+
+interface ConfirmSignoutModalProps {
+  isOpen: boolean;
+  onDissmissModal?: (value: boolean) => void;
+  signout?: (isDeposit: boolean) => void;
+}
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+  '.MuiPaper-root': {
+    background: theme.palette.background.default,
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    width: '500px',
+    maxHeight: '100%',
+    padding: '16px',
+    margin: '0',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%'
+    }
+  },
+
+  '.MuiIconButton-root': {
+    width: 'fit-content',
+    svg: {
+      fontSize: '32px'
+    }
+  },
+
+  '.MuiDialogTitle-root': {
+    padding: '0 16px',
+    paddingTop: '16px',
+    fontSize: '26px',
+    textAlign: 'center'
+  },
+
+  '.MuiDialogContent-root': {
+    padding: '0'
+  },
+
+  '.MuiDialogActions-root': {
+    justifyContent: 'space-evenly',
+
+    button: {
+      textTransform: 'none',
+      width: '100%',
+      '&.confirm-btn': {
+        color: theme.palette.common.white
+      }
+    }
+  },
+
+  '.back-btn': {
+    padding: '0',
+    position: 'absolute',
+    left: '8px',
+    top: '20px',
+    borderRadius: '12px',
+    svg: {
+      fontSize: '32px'
+    }
+  }
+}));
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & {
+    children: React.ReactElement;
+  },
+  ref: React.Ref<unknown>
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
+
+const ConfirmSignoutModal: React.FC<ConfirmSignoutModalProps> = props => {
+  return (
+    <React.Fragment>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+          <ChevronLeft />
+        </IconButton>
+        <DialogTitle paddingTop="0px !important">Confirm signout</DialogTitle>
+        <DialogContent>
+          <Typography variant="body1" sx={{ marginTop: '10px' }}>
+            This step will sign out of the current session. Are you sure want to continue?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            className="confirm-btn"
+            variant="contained"
+            color="warning"
+            onClick={() => {
+              props.signout!(false);
+            }}
+            autoFocus
+          >
+            Not signout
+          </Button>
+          <Button
+            className="confirm-btn"
+            variant="contained"
+            color="success"
+            onClick={() => {
+              props.signout!(true);
+            }}
+            autoFocus
+          >
+            Signout
+          </Button>
+        </DialogActions>
+      </StyledDialog>
+    </React.Fragment>
+  );
+};
+
+export default ConfirmSignoutModal;

--- a/apps/telegram-ecash-escrow/src/components/Settings/ConfirmSignoutModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Settings/ConfirmSignoutModal.tsx
@@ -18,8 +18,8 @@ import React from 'react';
 
 interface ConfirmSignoutModalProps {
   isOpen: boolean;
-  onDissmissModal?: (value: boolean) => void;
-  signout?: (isDeposit: boolean) => void;
+  onDismissModal?: (value: boolean) => void;
+  signout?: (isSignout: boolean) => void;
 }
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
@@ -90,8 +90,8 @@ const Transition = React.forwardRef(function Transition(
 const ConfirmSignoutModal: React.FC<ConfirmSignoutModalProps> = props => {
   return (
     <React.Fragment>
-      <StyledDialog open={props.isOpen} onClose={() => props.onDissmissModal!(false)} TransitionComponent={Transition}>
-        <IconButton className="back-btn" onClick={() => props.onDissmissModal!(false)}>
+      <StyledDialog open={props.isOpen} onClose={() => props.onDismissModal!(false)} TransitionComponent={Transition}>
+        <IconButton className="back-btn" onClick={() => props.onDismissModal!(false)}>
           <ChevronLeft />
         </IconButton>
         <DialogTitle paddingTop="0px !important">Confirm signout</DialogTitle>

--- a/apps/telegram-ecash-escrow/src/components/TickerHeader/TickerHeader.tsx
+++ b/apps/telegram-ecash-escrow/src/components/TickerHeader/TickerHeader.tsx
@@ -2,9 +2,8 @@
 
 import { openModal, PostQueryItem, useSliceDispatch as useLixiSliceDispatch } from '@bcpros/redux-store';
 import { ChevronLeft } from '@mui/icons-material';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import ShareIcon from '@mui/icons-material/Share';
-import { IconButton, Typography } from '@mui/material';
+import { Button, IconButton, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
@@ -47,6 +46,11 @@ const Header = styled('div')(({ theme }) => ({
       fontSize: '30px',
       color: '#3383ff'
     }
+  },
+
+  '.btn-create-offer': {
+    padding: '3px 5px',
+    right: '10px'
   }
 }));
 
@@ -97,7 +101,12 @@ const TickerHeader: React.FC<TickerHeaderProps> = ({
       )}
       <Typography variant="h4">
         {iconHeader && <IconButton className="icon-header">{iconHeader}</IconButton>}
-        {title} {showBtnCreateOffer && <AddCircleOutlineIcon onClick={handleOpenCreateOffer} />}{' '}
+        {title}{' '}
+        {showBtnCreateOffer && (
+          <Button className="btn-create-offer" variant="contained" color="info" onClick={handleOpenCreateOffer}>
+            Create
+          </Button>
+        )}{' '}
       </Typography>
       {showShareIcon && (
         <IconButton

--- a/apps/telegram-ecash-escrow/src/components/TopSection/TopSection.tsx
+++ b/apps/telegram-ecash-escrow/src/components/TopSection/TopSection.tsx
@@ -60,7 +60,7 @@ const TopSection: React.FC = () => {
         </div>
       </TopSectionWrap>
 
-      <FilterOfferModal isOpen={open} onDissmissModal={value => setOpen(value)} />
+      <FilterOfferModal isOpen={open} onDismissModal={value => setOpen(value)} />
     </>
   );
 };

--- a/apps/telegram-ecash-escrow/src/store/constants.ts
+++ b/apps/telegram-ecash-escrow/src/store/constants.ts
@@ -11,7 +11,7 @@ export enum TabType {
 }
 
 export const COIN_OTHERS = 'Others';
-export const COIN_USD_STABLECOIN = 'USD Stablecoins';
+export const COIN_USD_STABLECOIN = 'USD Stablecoin';
 export const COIN_USD_STABLECOIN_TICKER = 'USD';
 
 export const LIST_COIN = [


### PR DESCRIPTION
fix: update incorrect links in Offer ID and local eCash channel (#277, #284)
fix: allow moderators to use /stats command when losing seeds (#287)

feat: revamp taker's security deposit option (#279)
feat: rework Offer Detail filter (#280)

ui: minor UI updates on Home screen (#281)
ui: minor UI updates for Offer and Order screens (#282)
ui: minor UI updates on Settings screen, add backup reminder when signing out (#283)

warn: show warning about losing access to old account when creating new seeds (#286)