### PR TITLE
Multiple UI & UX improvements:

### DIFF
--- a/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/order-detail/page.tsx
@@ -8,7 +8,7 @@ import QRCode from '@/src/components/QRcode/QRcode';
 import TelegramButton from '@/src/components/TelegramButton/TelegramButton';
 import TickerHeader from '@/src/components/TickerHeader/TickerHeader';
 import CustomToast from '@/src/components/Toast/CustomToast';
-import { COIN_OTHERS } from '@/src/store/constants';
+import { COIN_OTHERS, securityDepositPercentage } from '@/src/store/constants';
 import { SettingContext } from '@/src/store/context/settingProvider';
 import { UtxoContext } from '@/src/store/context/utxoProvider';
 import {
@@ -110,17 +110,17 @@ const OrderDetail = () => {
   const { totalValidAmount, totalValidUtxos } = useContext(UtxoContext);
 
   const CLAIM_BACK_WALLET = {
-    label: '💼 Claim my security deposit back to my wallet',
+    label: `💼 Claim my security deposit (${securityDepositPercentage}%) back to my wallet`,
     value: 1
   };
 
   const DONATE_ARBITRATOR = {
-    label: '⚖️ Donate my security deposit to Arbitrator',
+    label: `⚖️ Donate my security deposit (${securityDepositPercentage}%) to Arbitrator`,
     value: 2
   };
 
   const DONATE_LOCAL_ECASH = {
-    label: '💙 Donate my security deposit to Local eCash',
+    label: `💙 Donate my security deposit (${securityDepositPercentage}%) to Local eCash`,
     value: 3
   };
 
@@ -542,6 +542,27 @@ const OrderDetail = () => {
     setOpenToastCopySuccess(true);
   };
 
+  const safeComponent = (content: string) => {
+    return (
+      <React.Fragment>
+        <Stack direction="row" spacing={2} justifyContent="center" margin="20px">
+          <Image width={50} height={50} src="/safebox-open.svg" alt="" />
+          <Stack direction="row" spacing={0} justifyContent="center" color="white" alignItems="center">
+            <HorizontalRuleIcon className="icon-rule" />
+            <HorizontalRuleIcon className="icon-rule" />
+            <ClearIcon color="error" />
+            <HorizontalRuleIcon className="icon-rule" />
+            <TrendingFlatIcon className="icon-rule" />
+          </Stack>
+          <Image width={50} height={50} src="/safebox-close.svg" alt="" />
+        </Stack>
+        <Typography variant="body1" color="error" align="center">
+          {content}
+        </Typography>
+      </React.Fragment>
+    );
+  };
+
   const escrowStatus = () => {
     const isSeller = selectedWalletPath?.hash160 === currentData?.escrowOrder.sellerAccount.hash160;
     const isArbiOrMod =
@@ -586,7 +607,9 @@ const OrderDetail = () => {
                   </p>
                 </div>
               ) : (
-                'Please escrow the order'
+                safeComponent(
+                  'Payment will only be made once the order is escrowed. You may want to chat with the buyer for further agreement and details prior to escrow.'
+                )
               )}
               {InfoEscrow()}
             </div>
@@ -603,21 +626,9 @@ const OrderDetail = () => {
           <Typography variant="body1" color="error" align="center">
             Pending Escrow!
           </Typography>
-          <Stack direction="row" spacing={2} justifyContent="center" margin="20px">
-            <Image width={50} height={50} src="/safebox-open.svg" alt="" />
-            <Stack direction="row" spacing={0} justifyContent="center" color="white" alignItems="center">
-              <HorizontalRuleIcon className="icon-rule" />
-              <HorizontalRuleIcon className="icon-rule" />
-              <ClearIcon color="error" />
-              <HorizontalRuleIcon className="icon-rule" />
-              <TrendingFlatIcon className="icon-rule" />
-            </Stack>
-            <Image width={50} height={50} src="/safebox-close.svg" alt="" />
-          </Stack>
-          <Typography variant="body1" color="error" align="center">
-            Once the order is escrowed, the status will turn green with a closed safe icon. Do not send money or goods
-            until the order is escrowed, or you risk losing money.
-          </Typography>
+          {safeComponent(
+            ' Once the order is escrowed, the status will turn green with a closed safe icon. Do not send money or goods until the order is escrowed, or you risk losing money.'
+          )}
         </React.Fragment>
       );
     }
@@ -854,19 +865,13 @@ const OrderDetail = () => {
         <div>
           {telegramButton(true, 'Chat with seller for payment details')}
           <div className="group-button-wrap">
-            {isBuyOffer ? (
-              currentData.escrowOrder?.markAsPaid ? (
-                <Button color="warning" variant="contained" disabled={loading} onClick={() => handleCreateDispute()}>
-                  Dispute
-                </Button>
-              ) : (
-                <Button color="warning" variant="contained" disabled={loading} onClick={() => handleMarkAsPaid()}>
-                  Mark as paid
-                </Button>
-              )
-            ) : (
+            {currentData.escrowOrder?.markAsPaid ? (
               <Button color="warning" variant="contained" disabled={loading} onClick={() => handleCreateDispute()}>
                 Dispute
+              </Button>
+            ) : (
+              <Button color="warning" variant="contained" disabled={loading} onClick={() => handleMarkAsPaid()}>
+                Mark as paid
               </Button>
             )}
             <Button
@@ -1005,7 +1010,7 @@ const OrderDetail = () => {
           Your wallet: {totalBalanceFormat} {COIN.XEC}
         </Typography>
         <Typography>
-          Security deposit (1%): {formatNumber(fee1Percent)} {COIN.XEC}
+          Security deposit ({securityDepositPercentage}%): {formatNumber(fee1Percent)} {COIN.XEC}
         </Typography>
         <Typography>
           Withdraw fee: {formatNumber(estimatedFee(currentData?.escrowOrder.escrowScript))} {COIN.XEC}

--- a/apps/telegram-ecash-escrow/src/app/profile/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import OfferDetailInfo from '@/src/components/DetailInfo/OfferDetailInfo';
 import Header from '@/src/components/Header/Header';
 import MobileLayout from '@/src/components/layout/MobileLayout';
 import { SettingContext } from '@/src/store/context/settingProvider';
+import { formatNumber } from '@/src/store/util';
 import { accountsApi, PostQueryItem, useInfiniteActiveOfferByAccountIdDatabaseQuery } from '@bcpros/redux-store';
 import { ChevronLeft } from '@mui/icons-material';
 import AccountCircleRoundedIcon from '@mui/icons-material/AccountCircleRounded';
@@ -188,7 +189,9 @@ const ProfileDetail = () => {
           <div className="info-detail">
             <div>
               <Typography className="info-item">
-                Donation: {loadingInfo(accountQueryData?.getAccountByAddress?.accountStatsOrder?.donationAmount)} XEC
+                Donation:{' '}
+                {loadingInfo(formatNumber(accountQueryData?.getAccountByAddress?.accountStatsOrder?.donationAmount))}{' '}
+                XEC
               </Typography>
             </div>
             <div>

--- a/apps/telegram-ecash-escrow/src/components/Action/ConfirmCancelModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Action/ConfirmCancelModal.tsx
@@ -2,6 +2,7 @@
 
 import { styled } from '@mui/material/styles';
 
+import { securityDepositPercentage } from '@/src/store/constants';
 import { ChevronLeft } from '@mui/icons-material';
 import {
   Button,
@@ -100,11 +101,11 @@ const ConfirmCancelModal: React.FC<ConfirmCancelModalProps> = props => {
 
   const OptionDonate = [
     {
-      label: '💼 Claim my security deposit back to my wallet',
+      label: `💼 Claim my security deposit (${securityDepositPercentage}%) back to my wallet`,
       value: false
     },
     {
-      label: `💙 Donate my security deposit to Local eCash`,
+      label: `💙 Donate my security deposit (${securityDepositPercentage}%) to Local eCash`,
       value: true
     }
   ];

--- a/apps/telegram-ecash-escrow/src/components/Action/ConfirmReleaseModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Action/ConfirmReleaseModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { securityDepositPercentage } from '@/src/store/constants';
 import { ChevronLeft } from '@mui/icons-material';
 import {
   Button,
@@ -103,11 +104,11 @@ const ConfirmReleaseModal: React.FC<ConfirmReleaseModalProps> = (props: ConfirmR
   const [verified, setVerified] = useState(false);
   const OptionDonate = [
     {
-      label: '💼 Claim my security deposit back to my wallet',
+      label: `💼 Claim my security deposit (${securityDepositPercentage}%) back to my wallet`,
       value: false
     },
     {
-      label: `💙 Donate my security deposit to Local eCash`,
+      label: `💙 Donate my security deposit (${securityDepositPercentage}%) to Local eCash`,
       value: true
     }
   ];

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -1189,6 +1189,13 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
             </div>
           </div>
         </Grid>
+        {getValues('paymentApp') && (
+          <Grid item xs={12}>
+            <Typography variant="body1">
+              <span className="prefix">Payment-App: </span> {getValues('paymentApp')}
+            </Typography>
+          </Grid>
+        )}
         <Grid item xs={12}>
           <Typography variant="body1">
             <span className="prefix">Headline: </span> {getValues('message')}

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -10,6 +10,7 @@ import {
   PostQueryItem,
   TimelineQueryItem,
   getSeedBackupTime,
+  getSelectedAccountId,
   openActionSheet,
   openModal,
   useSliceDispatch as useLixiSliceDispatch,
@@ -21,7 +22,7 @@ import { styled } from '@mui/material/styles';
 import { useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import useAuthorization from '../Auth/use-authorization.hooks';
 import { BackupModalProps } from '../Common/BackupModal';
 import { BuyButtonStyled } from '../OfferItem/OfferItem';
@@ -80,6 +81,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
   const { status } = useSession();
   const askAuthorization = useAuthorization();
 
+  const selectedAccountId = useLixiSliceSelector(getSelectedAccountId);
   const lastSeedBackupTimeOnDevice = useLixiSliceSelector(getSeedBackupTime);
   const settingContext = useContext(SettingContext);
   const seedBackupTime = settingContext?.setting?.lastSeedBackupTime ?? lastSeedBackupTimeOnDevice ?? '';
@@ -89,6 +91,8 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
   const countryName = offerData?.location?.country;
   const stateName = offerData?.location?.adminNameAscii;
   const cityName = offerData?.location?.cityAscii;
+
+  const isOwner = (postData ?? post)?.accountId === selectedAccountId;
 
   const handleClickAction = e => {
     e.stopPropagation();
@@ -177,16 +181,20 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
         ) : (
           <>
             <div className="payment-group-btns">
-              <Button size="small" color="info" variant="outlined">
-                <Typography variant="body1" style={{ fontWeight: 'bold' }}>
-                  <span style={{ fontSize: '14px' }}>{offerData?.hideFromHome ? 'Unlisted' : 'Listed'}</span>
-                </Typography>
-              </Button>
-              <Button size="small" color="info" variant="outlined">
-                <Typography variant="body1" style={{ fontWeight: 'bold' }}>
-                  <span style={{ fontSize: '14px' }}>{offerData?.type == OfferType.Buy ? 'Buy' : 'Sell'}</span>
-                </Typography>
-              </Button>
+              {isOwner && (
+                <React.Fragment>
+                  <Button size="small" color="info" variant="outlined">
+                    <Typography variant="body1" style={{ fontWeight: 'bold' }}>
+                      <span style={{ fontSize: '14px' }}>{offerData?.hideFromHome ? 'Unlisted' : 'Listed'}</span>
+                    </Typography>
+                  </Button>
+                  <Button size="small" color="info" variant="outlined">
+                    <Typography variant="body1" style={{ fontWeight: 'bold' }}>
+                      <span style={{ fontSize: '14px' }}>{offerData?.type == OfferType.Buy ? 'Buy' : 'Sell'}</span>
+                    </Typography>
+                  </Button>
+                </React.Fragment>
+              )}
               {offerData?.paymentMethods &&
                 offerData.paymentMethods?.length > 0 &&
                 offerData.paymentMethods.map(item => {

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/ConfirmDepositModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/ConfirmDepositModal.tsx
@@ -2,6 +2,7 @@
 
 import { styled } from '@mui/material/styles';
 
+import { securityDepositPercentage } from '@/src/store/constants';
 import { formatNumber } from '@/src/store/util';
 import { COIN } from '@bcpros/lixi-models';
 import { ChevronLeft } from '@mui/icons-material';
@@ -105,7 +106,7 @@ const ConfirmDepositModal: React.FC<ConfirmDepositModalProps> = props => {
             returned if there is no dispute.
           </Typography>
           <Typography variant="body1" sx={{ marginTop: '10px', fontWeight: 'bold' }}>
-            Security deposit (1%): {formatNumber(props.depositSecurity)} {COIN.XEC}
+            Security deposit ({securityDepositPercentage}%): {formatNumber(props.depositSecurity)} {COIN.XEC}
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/apps/telegram-ecash-escrow/src/store/constants.ts
+++ b/apps/telegram-ecash-escrow/src/store/constants.ts
@@ -129,3 +129,5 @@ export const NAME_PAYMENT_METHOD = {
 export const ALL_CURRENCIES = 'All currencies';
 export const ALL_CATEGORIES = 'All categories';
 export const ALL = 'All';
+
+export const securityDepositPercentage = 1;


### PR DESCRIPTION
- Display Safe icon for Seller and Maker (Offeror) (#330, #347)
- Show security deposit % in Order details for both Buyer and Seller (#332)
- Apply rounding for XEC amount display (#344)
- Adjust Buy label position for better alignment (#346)
- Display selected payment app in "Create a new offer" screen (#338)
- Hide Listed/Unlisted info when viewing offer details from a third party (#345)
- Enable "Mark as Paid" action for Buy orders (#343)