### PR TITLE
fix: update Boosting messages to use Mini app link, disable Dispute b…

### DIFF
--- a/apps/telegram-ecash-escrow/package.json
+++ b/apps/telegram-ecash-escrow/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@bcpros/counter": "workspace:*",
-    "@bcpros/lixi-models": "1.2.60",
-    "@bcpros/redux-store": "1.2.60",
+    "@bcpros/lixi-models": "1.2.61",
+    "@bcpros/redux-store": "1.2.61",
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
@@ -290,7 +290,7 @@ const OrderDetailInfo = ({
         {order?.sellerAccount.id === selectedAccount?.id && (
           <React.Fragment>
             <span className="prefix">{order.escrowOffer.type === OfferType.Buy ? 'Offered' : 'Ordered'} by: </span>
-            {allSettings[`${order?.buyerAccount.id.toString()}`]?.usePublicLocalUserName
+            {allSettings?.[`${order?.buyerAccount.id.toString()}`]?.usePublicLocalUserName
               ? order?.buyerAccount.anonymousUsernameLocalecash
               : order?.buyerAccount.telegramUsername}
           </React.Fragment>
@@ -298,7 +298,7 @@ const OrderDetailInfo = ({
         {order?.buyerAccount.id === selectedAccount?.id && (
           <React.Fragment>
             <span className="prefix">{order.escrowOffer.type === OfferType.Buy ? 'Ordered' : 'Offered'} by: </span>
-            {allSettings[`${order?.sellerAccount.id.toString()}`]?.usePublicLocalUserName
+            {allSettings?.[`${order?.sellerAccount.id.toString()}`]?.usePublicLocalUserName
               ? order?.sellerAccount.anonymousUsernameLocalecash
               : order?.sellerAccount.telegramUsername}
           </React.Fragment>

--- a/apps/telegram-ecash-escrow/src/components/Header/Header.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Header/Header.tsx
@@ -118,6 +118,13 @@ export default function Header() {
 
   const contentMoreAction = (
     <PopoverStyled>
+      <Typography
+        onClick={() => router.push(`/profile?address=${selectedAccount?.address}`)}
+        className="heading-profile"
+      >
+        <span>Profile</span>
+        <Button className="no-border-btn" endIcon={<Person2Icon />} />
+      </Typography>
       <Typography onClick={() => router.push('/wallet')} className="heading-profile">
         <span>Wallet</span>
         <Button className="no-border-btn" endIcon={<Wallet />} />
@@ -136,13 +143,6 @@ export default function Header() {
       <Typography onClick={() => router.push('/settings')} className="heading-profile">
         <span>Settings</span>
         <Button className="no-border-btn" endIcon={<SettingsOutlined />} />
-      </Typography>
-      <Typography
-        onClick={() => router.push(`/profile?address=${selectedAccount?.address}`)}
-        className="heading-profile"
-      >
-        <span>Profile</span>
-        <Button className="no-border-btn" endIcon={<Person2Icon />} />
       </Typography>
     </PopoverStyled>
   );

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
@@ -785,7 +785,7 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
         <Typography className="offer-info" variant="body2">
           <Typography component="span" variant="body1">{`Offer Id: ${post.id}`}</Typography>
           <br />
-          <Typography component="span">{`By: ${allSettings[`${post.account.id.toString()}`]?.usePublicLocalUserName ? post.account.anonymousUsernameLocalecash : post.account.telegramUsername} • posted on: ${new Date(post.createdAt).toLocaleString('vi-VN')}`}</Typography>
+          <Typography component="span">{`By: ${allSettings?.[`${post.account.id.toString()}`]?.usePublicLocalUserName ? post.account.anonymousUsernameLocalecash : post.account.telegramUsername} • posted on: ${new Date(post.createdAt).toLocaleString('vi-VN')}`}</Typography>
         </Typography>
         <DialogContent>
           <PlaceAnOrderWrap>

--- a/apps/telegram-ecash-escrow/src/components/ToastNotificationManage.tsx
+++ b/apps/telegram-ecash-escrow/src/components/ToastNotificationManage.tsx
@@ -17,25 +17,19 @@ const ToastNotificationManage = () => {
   const currentToast = useLixiSliceSelector(getToastNotification);
   const currentTheme = useLixiSliceSelector(getCurrentThemes);
   const dispatch = useLixiSliceDispatch();
+
   const [open, setOpen] = useState(false);
   const [type, setType] = useState('');
   const [description, setDescription] = useState('');
   const [duration, setDuration] = useState(DURATION_DEFAULT);
+  const [isLink, setIsLink] = useState(false);
+  const [linkDescription, setLinkDescription] = useState('');
 
   useEffect(() => {
     if (currentToast) {
       const { type, config, isLink, linkDescription } = currentToast;
       if (config && !_.isEmpty(config.description)) {
         const newConfig = _.cloneDeep(config);
-
-        //process link
-        if (isLink) {
-          newConfig.description = (
-            <a href={`${newConfig.description}`} target="_blank" rel="noopener noreferrer">
-              <p>{linkDescription}</p>
-            </a>
-          );
-        }
 
         newConfig.placement = 'topLeft'; //fault of lib (top is topLeft, topLeft is top)
         newConfig.className = `custom-toast-notification ${
@@ -47,6 +41,8 @@ const ToastNotificationManage = () => {
         setType(type);
         setDescription(newConfig?.description as string);
         setDuration(newConfig.duration);
+        setIsLink(isLink || false);
+        setLinkDescription(linkDescription || '');
 
         setOpen(true);
         dispatch(closeToast());
@@ -61,6 +57,8 @@ const ToastNotificationManage = () => {
       handleClose={() => setOpen(false)}
       autoHideDuration={duration * 1000}
       type={type as Exclude<ToastType, 'open' | 'burn'>}
+      isLink={isLink}
+      linkDescription={linkDescription}
     />
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,11 +59,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/counter
       '@bcpros/lixi-models':
-        specifier: 1.2.60
-        version: 1.2.60(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(class-transformer@0.5.1)(graphql@16.8.1)(reflect-metadata@0.2.2)
+        specifier: 1.2.61
+        version: 1.2.61(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(class-transformer@0.5.1)(graphql@16.8.1)(reflect-metadata@0.2.2)
       '@bcpros/redux-store':
-        specifier: 1.2.60
-        version: 1.2.60(@abcpros/bitcore-lib-xpi@8.25.43)(@bcpros/xpi-js@4.0.6)(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@rtk-query/graphql-request-base-query@2.3.1(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(graphql@16.8.1))(axios@0.30.0)(chronik-client@0.26.2)(class-transformer@0.5.1)(file-saver@2.0.5)(iron-session@8.0.1)(moment@2.30.1)(react-device-detect@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-intl-universal@2.11.1(react@18.3.1))(react-outside-call@0.2.0)(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist-indexeddb-storage@1.0.4)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux-saga@1.3.0)(redux-thunk@3.1.0(redux@5.0.1))(redux@5.0.1)(reflect-metadata@0.2.2)
+        specifier: 1.2.61
+        version: 1.2.61(@abcpros/bitcore-lib-xpi@8.25.43)(@bcpros/xpi-js@4.0.6)(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@rtk-query/graphql-request-base-query@2.3.1(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(graphql@16.8.1))(axios@0.30.0)(chronik-client@0.26.2)(class-transformer@0.5.1)(file-saver@2.0.5)(iron-session@8.0.1)(moment@2.30.1)(react-device-detect@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-intl-universal@2.11.1(react@18.3.1))(react-outside-call@0.2.0)(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist-indexeddb-storage@1.0.4)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux-saga@1.3.0)(redux-thunk@3.1.0(redux@5.0.1))(redux@5.0.1)(reflect-metadata@0.2.2)
       '@emotion/cache':
         specifier: ^11.11.0
         version: 11.11.0
@@ -831,15 +831,15 @@ packages:
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
-  '@bcpros/lixi-models@1.2.60':
-    resolution: {integrity: sha512-sgt5GDqk2cAQOF/nqzC30HqGIBbg0jVzh5VrEqJUmVOafde9oFQ5dfKO2cAd7JJ1ZftfwCPrWGyPCF36DwUEiA==}
+  '@bcpros/lixi-models@1.2.61':
+    resolution: {integrity: sha512-J2pjbmi4mlUZxBkdeLEQKC+mZ1kHggPKWz0XvrXJgyU0sGHErinRo08lbfU8HZr6jH0eDUaGwTL6NNnRioBQmQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@prisma/client': 5.12.1
       class-transformer: ^0.5.1
 
-  '@bcpros/redux-store@1.2.60':
-    resolution: {integrity: sha512-G4roZLEwsJp+5lCWZX+4ApZlJk+EoUS1zzUWagXCNKy8i5coxe9CTSYOUDpWpmjCTH8xpzCQ0LtLmeOFp/zaYw==}
+  '@bcpros/redux-store@1.2.61':
+    resolution: {integrity: sha512-er83RAVZikVGLrYt2qWEuyQCLdqmY0yrx/IvhNpqmXLTi9yh7STAnOGr1D7E2ZAtgWbsgi8OyUVQOQAJZ2PJ/g==}
     peerDependencies:
       '@abcpros/bitcore-lib-xpi': '>=8.25.37'
       '@bcpros/xpi-js': 4.0.6
@@ -5914,7 +5914,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@bcpros/lixi-models@1.2.60(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(class-transformer@0.5.1)(graphql@16.8.1)(reflect-metadata@0.2.2)':
+  '@bcpros/lixi-models@1.2.61(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(class-transformer@0.5.1)(graphql@16.8.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@prisma/client': 5.14.0
@@ -5930,10 +5930,10 @@ snapshots:
       - graphql
       - reflect-metadata
 
-  '@bcpros/redux-store@1.2.60(@abcpros/bitcore-lib-xpi@8.25.43)(@bcpros/xpi-js@4.0.6)(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@rtk-query/graphql-request-base-query@2.3.1(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(graphql@16.8.1))(axios@0.30.0)(chronik-client@0.26.2)(class-transformer@0.5.1)(file-saver@2.0.5)(iron-session@8.0.1)(moment@2.30.1)(react-device-detect@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-intl-universal@2.11.1(react@18.3.1))(react-outside-call@0.2.0)(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist-indexeddb-storage@1.0.4)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux-saga@1.3.0)(redux-thunk@3.1.0(redux@5.0.1))(redux@5.0.1)(reflect-metadata@0.2.2)':
+  '@bcpros/redux-store@1.2.61(@abcpros/bitcore-lib-xpi@8.25.43)(@bcpros/xpi-js@4.0.6)(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(@rtk-query/graphql-request-base-query@2.3.1(@reduxjs/toolkit@2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1))(graphql@16.8.1))(axios@0.30.0)(chronik-client@0.26.2)(class-transformer@0.5.1)(file-saver@2.0.5)(iron-session@8.0.1)(moment@2.30.1)(react-device-detect@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-intl-universal@2.11.1(react@18.3.1))(react-outside-call@0.2.0)(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1)(redux-persist-indexeddb-storage@1.0.4)(redux-persist@6.0.0(react@18.3.1)(redux@5.0.1))(redux-saga@1.3.0)(redux-thunk@3.1.0(redux@5.0.1))(redux@5.0.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@abcpros/bitcore-lib-xpi': 8.25.43
-      '@bcpros/lixi-models': 1.2.60(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(class-transformer@0.5.1)(graphql@16.8.1)(reflect-metadata@0.2.2)
+      '@bcpros/lixi-models': 1.2.61(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@prisma/client@5.14.0)(class-transformer@0.5.1)(graphql@16.8.1)(reflect-metadata@0.2.2)
       '@bcpros/xpi-js': 4.0.6
       '@bitgo/utxo-lib': 9.40.0
       '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.0.14(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)


### PR DESCRIPTION
…utton after delay, and restrict Chat for Buy XEC offers

- Messages in Boosting offers now link to the Mini app (configurable) instead of the PWA app (#358)
- "Dispute" button is disabled 15s after "Mark as paid" is clicked
- Chat button is disabled for offer maker in Buy XEC offers (#357)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to accept chat requests in order details, with improved Telegram chat button controls and new acceptance options.

- **Improvements**
  - Unified all toast notifications into a global system for consistent feedback.
  - Enhanced button group layouts for better responsiveness and usability.
  - Updated "Mark as paid" button to temporarily disable after use, reducing accidental multiple clicks.
  - Improved error handling to prevent runtime issues when user settings are unavailable.
  - Streamlined the profile menu for easier access.
  - Enhanced toast notifications with improved link handling and standardized error messages.

- **Bug Fixes**
  - Prevented errors when accessing user settings that may be undefined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->