### PR TITLE
refactor: replace CustomToast with showToast for notifications across…

### DIFF
--- a/apps/telegram-ecash-escrow/src/app/backup/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/backup/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import CustomToast from '@/src/components/Toast/CustomToast';
 import MobileLayout from '@/src/components/layout/MobileLayout';
 import { SettingContext } from '@/src/store/context/settingProvider';
 import { UpdateSettingCommand } from '@bcpros/lixi-models';
@@ -7,6 +6,7 @@ import {
   getSelectedAccountId,
   getWalletMnemonic,
   settingApi,
+  showToast,
   updateSeedBackupTime,
   useSliceDispatch as useLixiSliceDispatch,
   useSliceSelector as useLixiSliceSelector
@@ -92,7 +92,6 @@ export default function Backup() {
   const [countWord, setCountWord] = useState(0);
   const [libWord, setLibWord] = useState<string[]>([]);
   const [randomListFinal, setRandomListFinal] = useState<string[]>([]);
-  const [finished, setFinished] = useState(false);
   const [disableButton, setDisableButton] = useState(false);
 
   const router = useRouter();
@@ -116,7 +115,12 @@ export default function Backup() {
       console.log('err when update setting: ', err);
     }
 
-    setFinished(true);
+    dispatch(
+      showToast('success', {
+        message: 'success',
+        description: 'Congratulation!! Please store these seed in a secure place'
+      })
+    );
     setDisableButton(true);
     //router after 2s
     setTimeout(() => {
@@ -272,12 +276,6 @@ export default function Backup() {
             Back
           </Button>
         )}
-        <CustomToast
-          isOpen={finished}
-          content="Congratulation!! Please store these seed in a secure place"
-          handleClose={() => setFinished(false)}
-          type="success"
-        />
       </ContainerBackupGame>
     </MobileLayout>
   );

--- a/apps/telegram-ecash-escrow/src/app/settings/page.tsx
+++ b/apps/telegram-ecash-escrow/src/app/settings/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import ConfirmSignoutModal from '@/src/components/Settings/ConfirmSignoutModal';
-import CustomToast from '@/src/components/Toast/CustomToast';
 import MobileLayout from '@/src/components/layout/MobileLayout';
 import { SettingContext } from '@/src/store/context/settingProvider';
 import { UpdateSettingCommand } from '@bcpros/lixi-models';
@@ -15,6 +14,7 @@ import {
   setCurrentThemes,
   setIsSystemThemes,
   settingApi,
+  showToast,
   useSliceDispatch as useLixiSliceDispatch,
   useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
@@ -93,8 +93,6 @@ export default function Setting() {
     { skip: !selectedWallet?.xAddress }
   );
 
-  const [openToastCopySuccess, setOpenToastCopySuccess] = useState(false);
-  const [openToastChangeIdentity, setOpenToastChangeIdentity] = useState(false);
   const [openSignoutModal, setOpenSignoutModal] = useState(false);
 
   const themeOptions = [
@@ -129,7 +127,12 @@ export default function Setting() {
   ];
 
   const handleOnCopy = () => {
-    setOpenToastCopySuccess(true);
+    dispatch(
+      showToast('info', {
+        message: 'info',
+        description: 'Copy to clipboard'
+      })
+    );
   };
 
   const handleSignOut = () => {
@@ -156,7 +159,12 @@ export default function Setting() {
       //setting on server
       const updatedSetting = await settingApi.updateSetting(updateSettingCommand);
       setSetting(updatedSetting);
-      setOpenToastChangeIdentity(true);
+      dispatch(
+        showToast('success', {
+          message: 'success',
+          description: 'Identity changed successfully!'
+        })
+      );
     }
   };
 
@@ -285,35 +293,7 @@ export default function Setting() {
               </AccordionDetails>
             </Accordion>
           </div>
-
-          {/*TODO: delete account*/}
-          {/* <div className="setting-item">
-          <p className="title">Delete account</p>
-          <Alert icon={<CheckCircleOutline className="ico-alert" fontSize="inherit" />} severity="error">
-            Delete your account in platform. You can import it later by seed phrase have been stored.
-          </Alert>
-          <Accordion className="collapse-backup-seed">
-            <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="panel1a-content" id="panel1a-header">
-              <p>Click to delete account</p>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Button onClick={handleDeleteAccount}>Delete</Button>
-            </AccordionDetails>
-          </Accordion>
-        </div> */}
         </div>
-        <CustomToast
-          isOpen={openToastCopySuccess}
-          handleClose={() => setOpenToastCopySuccess(false)}
-          content="Copy to clipboard"
-          type="info"
-        />
-        <CustomToast
-          isOpen={openToastChangeIdentity}
-          handleClose={() => setOpenToastChangeIdentity(false)}
-          content="Identity changed successfully!"
-          type="success"
-        />
       </ContainerSetting>
       <ConfirmSignoutModal
         isOpen={openSignoutModal}

--- a/apps/telegram-ecash-escrow/src/components/Header/Header.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Header/Header.tsx
@@ -7,19 +7,20 @@ import {
   getSelectedAccount,
   getSelectedWalletPath,
   parseCashAddressToPrefix,
+  showToast,
+  useSliceDispatch as useLixiSliceDispatch,
   useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
 import { CopyAllOutlined, SettingsOutlined, Wallet } from '@mui/icons-material';
 import AccountCircleRoundedIcon from '@mui/icons-material/AccountCircleRounded';
 import Person2Icon from '@mui/icons-material/Person2';
-import { Button, IconButton, Popover, Portal, Typography } from '@mui/material';
+import { Button, IconButton, Popover, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import React, { useContext, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import useAuthorization from '../Auth/use-authorization.hooks';
-import CustomToast from '../Toast/CustomToast';
 
 const StyledHeader = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -82,6 +83,7 @@ const StyledAvatar = styled('div')(({ theme }) => ({
 }));
 
 export default function Header() {
+  const dispatch = useLixiSliceDispatch();
   const router = useRouter();
   const { data, status } = useSession();
   const askAuthorization = useAuthorization();
@@ -96,7 +98,6 @@ export default function Header() {
   );
 
   const [address, setAddress] = useState(parseCashAddressToPrefix(COIN.XEC, selectedWalletPath?.cashAddress));
-  const [copy, setCopy] = useState(false);
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
 
@@ -131,7 +132,17 @@ export default function Header() {
       </Typography>
       <Typography variant="body1" align="center" className="item-address">
         <span className="address-amount"> {formatAddress(address)}</span>
-        <CopyToClipboard text={address} onCopy={() => setCopy(true)}>
+        <CopyToClipboard
+          text={address}
+          onCopy={() => {
+            dispatch(
+              showToast('info', {
+                message: 'info',
+                description: 'Address copied to clipboard'
+              })
+            );
+          }}
+        >
           <Button className="no-border-btn" endIcon={<CopyAllOutlined />} />
         </CopyToClipboard>
       </Typography>
@@ -184,14 +195,6 @@ export default function Header() {
           {contentMoreAction}
         </Popover>
       </div>
-      <Portal>
-        <CustomToast
-          isOpen={copy}
-          content="Address copied to clipboard"
-          handleClose={() => setCopy(false)}
-          type="success"
-        />
-      </Portal>
     </StyledHeader>
   );
 }

--- a/apps/telegram-ecash-escrow/src/components/QRcode/QRcode.tsx
+++ b/apps/telegram-ecash-escrow/src/components/QRcode/QRcode.tsx
@@ -1,12 +1,12 @@
 'use client';
 
+import { showToast, useSliceDispatch as useLixiSliceDispatch } from '@bcpros/redux-store';
 import styled from '@emotion/styled';
 import { CopyAllOutlined } from '@mui/icons-material';
-import { Button, Portal, Stack, Typography } from '@mui/material';
+import { Button, Stack, Typography } from '@mui/material';
 import RawQRCode from 'qrcode.react';
-import React, { useState } from 'react';
+import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import CustomToast from '../Toast/CustomToast';
 
 export const StyledRawQRCode = styled(RawQRCode)`
   cursor: pointer;
@@ -20,7 +20,7 @@ interface QRCodeProps {
 }
 
 const QRCode: React.FC<QRCodeProps> = ({ address, amount, width }) => {
-  const [copy, setCopy] = useState(false);
+  const dispatch = useLixiSliceDispatch();
   const formatAddress = (address: string) => {
     if (!address) return;
 
@@ -39,19 +39,20 @@ const QRCode: React.FC<QRCodeProps> = ({ address, amount, width }) => {
       />
       <Typography variant="body1" align="center">
         {formatAddress(address)}
-        <CopyToClipboard text={address} onCopy={() => setCopy(true)}>
+        <CopyToClipboard
+          text={address}
+          onCopy={() => {
+            dispatch(
+              showToast('info', {
+                message: 'info',
+                description: 'Address copied to clipboard'
+              })
+            );
+          }}
+        >
           <Button className="no-border-btn" endIcon={<CopyAllOutlined />} />
         </CopyToClipboard>
       </Typography>
-
-      <Portal>
-        <CustomToast
-          isOpen={copy}
-          content="Address copied to clipboard"
-          handleClose={() => setCopy(false)}
-          type="success"
-        />
-      </Portal>
     </Stack>
   );
 };

--- a/apps/telegram-ecash-escrow/src/components/Send/send.tsx
+++ b/apps/telegram-ecash-escrow/src/components/Send/send.tsx
@@ -8,6 +8,8 @@ import {
   getSelectedWalletPath,
   isValidCoinAddress,
   parseCashAddressToPrefix,
+  showToast,
+  useSliceDispatch as useLixiSliceDispatch,
   useSliceSelector as useLixiSliceSelector
 } from '@bcpros/redux-store';
 import styled from '@emotion/styled';
@@ -18,7 +20,6 @@ import cashaddr from 'ecashaddrjs';
 import React, { useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import ScanQRcode from '../QRcode/ScanQRcode';
-import CustomToast from '../Toast/CustomToast';
 
 const WrapComponent = styled.div`
   .address-input {
@@ -56,6 +57,7 @@ interface SendComponentProps {
 }
 
 const SendComponent: React.FC<SendComponentProps> = props => {
+  const dispatch = useLixiSliceDispatch();
   const { totalValidAmount, totalValidUtxos } = props;
 
   const selectedWallet = useLixiSliceSelector(getSelectedWalletPath);
@@ -88,8 +90,6 @@ const SendComponent: React.FC<SendComponentProps> = props => {
   );
 
   const [openScan, setOpenScan] = useState(false);
-  const [openToastSendSuccess, setOpenToastSendSuccess] = useState(false);
-  const [linkSend, setLinkSend] = useState('');
 
   const handleSendCoin = async data => {
     const { address, amount } = data;
@@ -113,8 +113,17 @@ const SendComponent: React.FC<SendComponentProps> = props => {
       const txid = (await chronik.broadcastTx(txBuild)).txid;
       const link = `${coinInfo[COIN.XEC].blockExplorerUrl}/tx/${txid}`;
       if (link) {
-        setLinkSend(link);
-        setOpenToastSendSuccess(true);
+        dispatch(
+          showToast(
+            'success',
+            {
+              message: 'success',
+              description: 'Transaction successful. Click to view in block explorer.'
+            },
+            true,
+            link
+          )
+        );
         reset();
       }
     } catch (err) {
@@ -233,15 +242,6 @@ const SendComponent: React.FC<SendComponentProps> = props => {
         setAddress={value => {
           setValue('address', value);
         }}
-      />
-
-      <CustomToast
-        isOpen={openToastSendSuccess}
-        handleClose={() => setOpenToastSendSuccess(false)}
-        content="Transaction successful. Click to view in block explorer."
-        isLink={true}
-        linkDescription={linkSend}
-        type="success"
       />
     </WrapComponent>
   );


### PR DESCRIPTION
… components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Centralized all toast notifications to use a global notification system, replacing local toast components and state management across multiple areas of the app.
	- Improved consistency for success and information messages, such as backup completion, address copying, identity changes, and transaction broadcasts.
	- Removed unused and redundant code related to previous local notification handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->