### PR TITLE
Fix close modal after create modal

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -364,46 +364,53 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
     dispatch(closeModal());
   };
 
+  const handleCloseModalWithDelay = (second = 1) => {
+    setTimeout(() => {
+      handleCloseModal();
+    }, second * 1000);
+  };
+
   // Helper function to check if margin should be shown
   const showMarginComponent = () => option !== PAYMENT_METHOD.GOODS_SERVICES;
 
   // Handler for creating/updating offers
   const handleCreateOffer = async (data: OfferFormValues, isHidden: boolean) => {
-    setLoading(true);
-    const minNum = getNumberFromFormatNumber(data.min) || null;
-    const maxNum = getNumberFromFormatNumber(data.max) || null;
-
-    const input = {
-      message: data.message,
-      noteOffer: data.note,
-      paymentMethodIds: [option],
-      coinPayment: data?.coin ? data.coin.split(':')[0] : null,
-      coinOthers: data?.coinOthers ? data.coinOthers : null,
-      priceCoinOthers: data?.priceCoinOthers ? getNumberFromFormatNumber(data.priceCoinOthers as unknown as string) : 0,
-      priceGoodsServices: data?.priceGoodsServices
-        ? getNumberFromFormatNumber(data.priceGoodsServices as unknown as string)
-        : 0,
-      tickerPriceGoodsServices: data?.tickerPriceGoodsServices ? data.tickerPriceGoodsServices : null,
-      localCurrency: data?.currency ? data.currency.split(':')[0] : null,
-      paymentApp: data?.paymentApp ? data.paymentApp : null,
-      marginPercentage: Number(data?.percentage ?? 0),
-      orderLimitMin: minNum,
-      orderLimitMax: maxNum,
-      locationId: data?.city?.id ?? null,
-      hideFromHome: isHidden
-    };
-
-    // Just have location when paymentmethod is CASH_IN_PERSON
-    if (option !== PAYMENT_METHOD.CASH_IN_PERSON) {
-      input.locationId = null;
-    }
-
-    if (option === PAYMENT_METHOD.GOODS_SERVICES) {
-      input.priceCoinOthers = 0;
-      input.coinOthers = null;
-    }
-
     try {
+      setLoading(true);
+      const minNum = getNumberFromFormatNumber(data.min) || null;
+      const maxNum = getNumberFromFormatNumber(data.max) || null;
+
+      const input = {
+        message: data.message,
+        noteOffer: data.note,
+        paymentMethodIds: [option],
+        coinPayment: data?.coin ? data.coin.split(':')[0] : null,
+        coinOthers: data?.coinOthers ? data.coinOthers : null,
+        priceCoinOthers: data?.priceCoinOthers
+          ? getNumberFromFormatNumber(data.priceCoinOthers as unknown as string)
+          : 0,
+        priceGoodsServices: data?.priceGoodsServices
+          ? getNumberFromFormatNumber(data.priceGoodsServices as unknown as string)
+          : 0,
+        tickerPriceGoodsServices: data?.tickerPriceGoodsServices ? data.tickerPriceGoodsServices : null,
+        localCurrency: data?.currency ? data.currency.split(':')[0] : null,
+        paymentApp: data?.paymentApp ? data.paymentApp : null,
+        marginPercentage: Number(data?.percentage ?? 0),
+        orderLimitMin: minNum,
+        orderLimitMax: maxNum,
+        locationId: data?.city?.id ?? null,
+        hideFromHome: isHidden
+      };
+
+      // Just have location when paymentmethod is CASH_IN_PERSON
+      if (option !== PAYMENT_METHOD.CASH_IN_PERSON) {
+        input.locationId = null;
+      }
+
+      if (option === PAYMENT_METHOD.GOODS_SERVICES) {
+        input.priceCoinOthers = 0;
+        input.coinOthers = null;
+      }
       if (isEdit) {
         const inputUpdateOffer: UpdateOfferInput = {
           message: data.message,
@@ -422,6 +429,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
             description: 'Offer updated successfully!'
           })
         );
+        handleCloseModalWithDelay();
       } else {
         const inputCreateOffer: CreateOfferInput = {
           ...input,
@@ -436,6 +444,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
             description: 'Offer created successfully!'
           })
         );
+        handleCloseModalWithDelay();
       }
     } catch (error) {
       console.error('Error creating/updating offer:', error);
@@ -445,6 +454,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
           description: `${isEdit ? 'Update' : 'Create'} offer failed!`
         })
       );
+      setLoading(false);
     }
   };
 
@@ -666,6 +676,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
                     setValue('percentage', 0);
                     setValue('coin', null);
                     setValue('currency', null);
+                    setValue('coinOthers', null);
                   }
                   onChange(e);
                 }}
@@ -948,72 +959,6 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
           </>
         )}
 
-        {/* Price fields for goods and services */}
-        {option === PAYMENT_METHOD.GOODS_SERVICES && (
-          <>
-            <Grid item xs={12}>
-              <Typography variant="body2" className="label">
-                Price
-              </Typography>
-            </Grid>
-
-            <Grid item xs={12} style={{ paddingTop: 0 }}>
-              <Controller
-                name="priceGoodsServices"
-                control={control}
-                rules={{
-                  required: {
-                    value: true,
-                    message: 'Price is required!'
-                  }
-                }}
-                render={({ field: { onChange, onBlur, value, name, ref } }) => (
-                  <FormControl style={{ width: '35%' }}>
-                    <NumericFormat
-                      allowLeadingZeros={false}
-                      allowNegative={false}
-                      thousandSeparator={true}
-                      decimalScale={8}
-                      customInput={TextField}
-                      onChange={onChange}
-                      onBlur={onBlur}
-                      value={value}
-                      name={name}
-                      inputRef={ref}
-                      className="form-input"
-                      id="priceGoodsServices"
-                      placeholder={`E.g. 1`}
-                      error={!!errors.priceGoodsServices}
-                      helperText={errors.priceGoodsServices?.message}
-                      variant="standard"
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            <Select
-                              defaultValue={getValues('tickerPriceGoodsServices') ?? DEFAULT_TICKER_GOODS_SERVICES}
-                              onChange={event => {
-                                setValue('tickerPriceGoodsServices', event.target.value);
-                              }}
-                              variant="standard"
-                              disableUnderline
-                            >
-                              {LIST_TICKER_GOODS_SERVICES.map(item => (
-                                <MenuItem key={item.id} value={item.name}>
-                                  {item.name}
-                                </MenuItem>
-                              ))}
-                            </Select>
-                          </InputAdornment>
-                        )
-                      }}
-                    />
-                  </FormControl>
-                )}
-              />
-            </Grid>
-          </>
-        )}
-
         {/* Location fields for cash in person */}
         {option === PAYMENT_METHOD.CASH_IN_PERSON && (
           <>
@@ -1197,6 +1142,73 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
         {/* Margin */}
         {showMarginComponent() && <MarginComponent />}
 
+        {/* Price fields for goods and services */}
+        {option === PAYMENT_METHOD.GOODS_SERVICES && (
+          <>
+            <Grid item xs={12}>
+              <Typography variant="body2" className="label">
+                Price
+              </Typography>
+            </Grid>
+
+            <Grid item xs={12} style={{ paddingTop: 0 }}>
+              <Controller
+                name="priceGoodsServices"
+                control={control}
+                rules={{
+                  required: {
+                    value: true,
+                    message: 'Price is required!'
+                  }
+                }}
+                render={({ field: { onChange, onBlur, value, name, ref } }) => (
+                  <FormControl style={{ width: '35%' }}>
+                    <NumericFormat
+                      allowLeadingZeros={false}
+                      allowNegative={false}
+                      thousandSeparator={true}
+                      decimalScale={8}
+                      customInput={TextField}
+                      onChange={onChange}
+                      onBlur={onBlur}
+                      value={value}
+                      name={name}
+                      inputRef={ref}
+                      className="form-input"
+                      id="priceGoodsServices"
+                      placeholder={`E.g. 1`}
+                      error={!!errors.priceGoodsServices}
+                      helperText={errors.priceGoodsServices?.message}
+                      variant="standard"
+                      InputProps={{
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <Select
+                              defaultValue={getValues('tickerPriceGoodsServices') ?? DEFAULT_TICKER_GOODS_SERVICES}
+                              onChange={event => {
+                                setValue('tickerPriceGoodsServices', event.target.value);
+                              }}
+                              variant="standard"
+                              disableUnderline
+                              disabled={isEdit}
+                            >
+                              {LIST_TICKER_GOODS_SERVICES.map(item => (
+                                <MenuItem key={item.id} value={item.name}>
+                                  {item.name}
+                                </MenuItem>
+                              ))}
+                            </Select>
+                          </InputAdornment>
+                        )
+                      }}
+                    />
+                  </FormControl>
+                )}
+              />
+            </Grid>
+          </>
+        )}
+
         {/* Order limits */}
         <OrderLimitWrap>
           <Typography variant="body2" className="label">
@@ -1233,7 +1245,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
                     inputRef={ref}
                     className="form-input"
                     id="min"
-                    placeholder={`Min: e.g. ${formatNumber(fixAmount)} ${coinCurrency}`}
+                    placeholder={`Min: e.g. ${isGoodService ? 1 : formatNumber(fixAmount)} ${coinCurrency}`}
                     error={!!errors.min}
                     helperText={errors.min?.message}
                     variant="standard"
@@ -1272,7 +1284,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
                     className="form-input"
                     id="max"
                     label=" "
-                    placeholder={`Max: e.g. ${formatNumber(fixAmount)} ${coinCurrency}`}
+                    placeholder={`Max: e.g. ${isGoodService ? 100 : formatNumber(fixAmount)} ${coinCurrency}`}
                     error={!!errors.max}
                     helperText={errors.max?.message}
                     variant="standard"
@@ -1323,7 +1335,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
   // Step 3: Review and confirmation
   const Step3Content = () => {
     const renderPricePreview = () => {
-      if (isEdit) {
+      if (isEdit && !isGoodService) {
         return (
           <Grid item xs={12} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
             <span>Price: </span>

--- a/apps/telegram-ecash-escrow/src/store/util.ts
+++ b/apps/telegram-ecash-escrow/src/store/util.ts
@@ -67,7 +67,14 @@ export const capitalizeStr = (str: string) => {
 
 export const getNumberFromFormatNumber = (value: string) => {
   if (!value) return 0;
-  return parseFloat(value.replace(/,/g, ''));
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (value?.includes(',')) {
+    return parseFloat(value.replace(/,/g, ''));
+  } else {
+    return parseFloat(value);
+  }
 };
 
 export const getOrderLimitText = (min: number | null, max: number | null, ticket: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Offer create/update modal now auto-closes after a short delay, moves goods/services price entry into step two with ticker selection, shows dynamic price previews across steps, updates min/max placeholders, and disables ticker changes in edit mode.
  * Number parsing improved to accept numeric inputs and handle comma-formatted strings more robustly.

* **Bug Fixes**
  * Selecting the goods/services payment method clears “other coin” and related fields.
  * Loading state is properly cleared on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->