### PR TITLE
fix: show goods/services unit in Order limit

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -534,11 +534,17 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
 
   // Effect to update coinCurrency when related form values change
   useEffect(() => {
+    // If the user selected Goods & Services payment method, show the unit label
+    if (option === PAYMENT_METHOD.GOODS_SERVICES) {
+      setCoinCurrency(GOODS_SERVICES_UNIT);
+      return;
+    }
+
     const currency = currencyValue?.split(':')[0];
     const coin = coinValue?.split(':')[0];
 
     setCoinCurrency(currency ?? (coin?.includes(COIN_OTHERS) ? getValues('coinOthers') : coin) ?? GOODS_SERVICES_UNIT);
-  }, [currencyValue, coinValue, getValues('coinOthers')]);
+  }, [currencyValue, coinValue, getValues('coinOthers'), option]);
 
   // Effect to load payment methods and countries on component mount
   useEffect(() => {


### PR DESCRIPTION
Ensure Order limit shows the goods/services unit (e.g. Unit) when user selects the Goods & Services payment method. This change sets the unit explicitly and updates effect dependencies so the label updates immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When choosing the Goods & Services payment method, the coin currency now automatically uses the Goods & Services unit for accurate pricing.
  * Coin/currency values now reliably update when changing the selected payment option, preventing stale or incorrect currency display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->