### PR TITLE
fix(CreateOfferModal): prevent currency override for Goods & Services…

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -517,7 +517,12 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
           // Set currency based on detected country
           const currencyDetected = LIST_CURRENCIES_USED.find(item => item.country === countryDetected?.iso2);
           if (currencyDetected) {
-            setValue('currency', `${currencyDetected?.code}:${currencyDetected?.fixAmount}`);
+            // Only set detected currency when the user hasn't selected Goods & Services
+            // to avoid overriding the 'Unit' display for goods/services offers.
+            const currentOption = Number(getValues('option'));
+            if (currentOption !== PAYMENT_METHOD.GOODS_SERVICES) {
+              setValue('currency', `${currencyDetected?.code}:${currencyDetected?.fixAmount}`);
+            }
           }
         }
       }


### PR DESCRIPTION
Stop geolocation-based currency detection from overriding the goods/services unit when user selected Goods & Services. This ensures the Order limit label remains "Unit" for goods/services offers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents geolocation from auto-overwriting the selected currency when creating Goods/Services offers; your chosen display unit remains unchanged.
  - Maintains auto-detected currency based on location for other payment options, preserving the previous behavior.
  - Improves consistency of currency selection during offer creation, reducing unexpected changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->