### PR TITLE
feat(create-offer): preview images/links in Create Offer preview and render attachments in offer list/detail

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -363,23 +363,34 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
   const renderTextWithLinks = (text?: string) => {
     if (!text) return null;
     const parts = text.split(URL_REGEX).filter(Boolean);
+    /**
+     * Only allow http and https URLs.
+     */
+    function isSafeHttpUrl(url: string): boolean {
+      return /^https?:\/\//i.test(url);
+    }
+
     return (
       <>
         {parts.map((part, idx) => {
           if (URL_REGEX.test(part)) {
             const url = part.trim();
-            if (IMAGE_EXT_REGEX.test(url)) {
+            if (isSafeHttpUrl(url)) {
+              if (IMAGE_EXT_REGEX.test(url)) {
+                return (
+                  <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
+                    <img src={url} alt="attachment" style={{ maxWidth: '100%', maxHeight: 300, borderRadius: 8, display: 'block', marginTop: 8 }} />
+                  </a>
+                );
+              }
               return (
-                <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                  <img src={url} alt="attachment" style={{ maxWidth: '100%', maxHeight: 300, borderRadius: 8, display: 'block', marginTop: 8 }} />
+                <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
+                  {url}
                 </a>
               );
             }
-            return (
-              <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
-                {url}
-              </a>
-            );
+            // Unsafe URL, render as plain text instead
+            return <span key={idx}>{url}</span>;
           }
           return <span key={idx}>{part}</span>;
         })}

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -356,6 +356,37 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
 
   const isGoodService = option === PAYMENT_METHOD.GOODS_SERVICES;
 
+  // Helper: detect URLs and render image preview or link
+  const URL_REGEX = /(https?:\/\/[^\s]+)/g;
+  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(\?|$)/i;
+
+  const renderTextWithLinks = (text?: string) => {
+    if (!text) return null;
+    const parts = text.split(URL_REGEX).filter(Boolean);
+    return (
+      <>
+        {parts.map((part, idx) => {
+          if (URL_REGEX.test(part)) {
+            const url = part.trim();
+            if (IMAGE_EXT_REGEX.test(url)) {
+              return (
+                <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
+                  <img src={url} alt="attachment" style={{ maxWidth: '100%', maxHeight: 300, borderRadius: 8, display: 'block', marginTop: 8 }} />
+                </a>
+              );
+            }
+            return (
+              <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
+                {url}
+              </a>
+            );
+          }
+          return <span key={idx}>{part}</span>;
+        })}
+      </>
+    );
+  };
+
   // Navigation handlers
   const handleNext = () => setActiveStep(prevStep => prevStep + 1);
   const handleBack = () => setActiveStep(prevStep => prevStep - 1);
@@ -1475,7 +1506,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
           {/* Headline */}
           <Grid item xs={12}>
             <Typography variant="body1">
-              <span className="prefix">Headline: </span> {getValues('message')}
+              <span className="prefix">Headline: </span> {renderTextWithLinks(getValues('message'))}
             </Typography>
           </Grid>
 
@@ -1505,7 +1536,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
           {getValues('note') && (
             <Grid item xs={12}>
               <Typography variant="body1">
-                <span className="prefix">Offer note: </span> {getValues('note')}
+                <span className="prefix">Offer note: </span> {renderTextWithLinks(getValues('note'))}
               </Typography>
             </Grid>
           )}

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -358,7 +358,20 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
 
   // Helper: detect URLs and render image preview or link
   const URL_REGEX = /(https?:\/\/[^\s]+)/g;
-  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(\?|$)/i;
+  // Only allow safe image extensions, no SVG
+  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp)(\?|$)/i;
+
+  // Additional image safety check
+  function isSafeImageUrl(url: string): boolean {
+    // Require http(s)
+    if (!/^https?:\/\//i.test(url)) return false;
+    // Disallow SVG entirely
+    if (/\.svg(\?|$)/i.test(url)) return false;
+    if (/^data:image\/svg\+xml/i.test(url)) return false;
+    // Only allow certain image extensions
+    if (!IMAGE_EXT_REGEX.test(url)) return false;
+    return true;
+  }
 
   const renderTextWithLinks = (text?: string) => {
     if (!text) return null;
@@ -376,12 +389,18 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
           if (URL_REGEX.test(part)) {
             const url = part.trim();
             if (isSafeHttpUrl(url)) {
-              if (IMAGE_EXT_REGEX.test(url)) {
+              if (isSafeImageUrl(url)) {
                 return (
                   <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                    <img src={url} alt="attachment" style={{ maxWidth: '100%', maxHeight: 300, borderRadius: 8, display: 'block', marginTop: 8 }} />
+                    <img 
+                      src={url}
+                      alt="attachment"
+                      style={{ maxWidth: '100%', maxHeight: 300, borderRadius: 8, display: 'block', marginTop: 8 }}
+                      loading="lazy"
+                    />
                   </a>
                 );
+              // Allowed plain links
               }
               return (
                 <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>

--- a/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/CreateOfferModal/CreateOfferModal.tsx
@@ -66,6 +66,7 @@ import {
 import { styled } from '@mui/material/styles';
 import { TransitionProps } from '@mui/material/transitions';
 import React, { useContext, useEffect, useRef, useState } from 'react';
+import renderTextWithLinks from '@/src/utils/linkHelpers';
 import { Controller, useForm } from 'react-hook-form';
 import { NumericFormat } from 'react-number-format';
 import FilterListLocationModal from '../FilterList/FilterListLocationModal';
@@ -356,89 +357,7 @@ const CreateOfferModal: React.FC<CreateOfferModalProps> = props => {
 
   const isGoodService = option === PAYMENT_METHOD.GOODS_SERVICES;
 
-  // Additional image safety check
-  // Accept only whitelisted image types and http(s) URLs from valid origins.
-  // Parse and validate http(s) URL; returns URL object or null
-  const parseSafeHttpUrl = (urlStr: string): URL | null => {
-    try {
-      const url = new URL(urlStr);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-      if (urlStr.startsWith('data:')) return null;
-      return url;
-    } catch (e) {
-      return null;
-    }
-  };
-
-  // Given a parsed URL, determine if it's a raster image we allow
-  const isSafeImageUrl = (url: URL): boolean => {
-    if (/\.svg(\?|$)/i.test(url.pathname)) return false;
-    return /\.(png|jpe?g|gif|bmp|webp)$/i.test(url.pathname);
-  };
-
-  // Strict URL sanitizer: returns a safe, normalized URL string or null when unsafe.
-  function sanitizeUrl(raw: string): string | null {
-    if (!raw || typeof raw !== 'string') return null;
-    const trimmed = raw.trim();
-    // quick reject dangerous schemes
-    const lower = trimmed.toLowerCase();
-    if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:') || lower.startsWith('file:') || lower.startsWith('blob:')) {
-      return null;
-    }
-    try {
-      const url = new URL(trimmed);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-      if (!url.hostname) return null;
-      // Reconstruct a normalized, encoded URL string
-      const port = url.port ? `:${url.port}` : '';
-      const path = encodeURI(url.pathname + url.search + url.hash);
-      return `${url.protocol}//${url.hostname}${port}${path}`;
-    } catch (e) {
-      return null;
-    }
-  }
-
-  // Use split with a non-global capturing regex to avoid stateful RegExp.test
-  const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
-  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(?:[?#].*|$)/i;
-
-  const renderTextWithLinks = (text?: string) => {
-    if (!text) return null;
-    const parts = text.split(URL_SPLIT_REGEX);
-    return (
-      <>
-            {parts.map((part, idx) => {
-              if (idx % 2 === 1) {
-                const url = part.trim();
-                const parsed = parseSafeHttpUrl(url);
-                const safe = sanitizeUrl(url);
-
-                // Image preview when parsed URL is a safe raster image and extension matches
-                if (parsed && isSafeImageUrl(parsed) && safe && IMAGE_EXT_REGEX.test(safe)) {
-                  return (
-                    <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                      <img src={safe} alt="attachment" style={{ maxWidth: '100%', maxHeight: 300, borderRadius: 8, display: 'block', marginTop: 8 }} loading="lazy" />
-                    </a>
-                  );
-                }
-
-                // Regular clickable link for safe http(s) URLs
-                if (parsed && safe) {
-                  return (
-                    <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
-                      {safe}
-                    </a>
-                  );
-                }
-
-                // Unsafe or unsanitizable URL: render plain text safely
-                return <span key={idx}>{url}</span>;
-              }
-              return <span key={idx}>{part}</span>;
-            })}
-      </>
-    );
-  };
+  // Use shared renderTextWithLinks utility imported above
 
   // Navigation handlers
   const handleNext = () => setActiveStep(prevStep => prevStep + 1);

--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -41,9 +41,8 @@ const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
     try {
       const url = new URL(trimmed);
       if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-      const port = url.port ? `:${url.port}` : '';
       const path = encodeURI(url.pathname + url.search + url.hash);
-      return `${url.protocol}//${url.hostname}${port}${path}`;
+      return `${url.protocol}//${url.host}${path}`;
     } catch (e) {
       return null;
     }

--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -29,6 +29,35 @@ const OrderDetailWrap = styled.div`
 `;
 
 const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
+  const URL_REGEX = /(https?:\/\/[^\s]+)/g;
+  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(\?|$)/i;
+
+  const renderTextWithLinks = (text?: string) => {
+    if (!text) return null;
+    const parts = text.split(URL_REGEX).filter(Boolean);
+    return (
+      <>
+        {parts.map((part, idx) => {
+          if (URL_REGEX.test(part)) {
+            const url = part.trim();
+            if (IMAGE_EXT_REGEX.test(url)) {
+              return (
+                <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
+                  <img src={url} alt="attachment" style={{ maxWidth: '100%', maxHeight: 220, borderRadius: 8, display: 'block', marginTop: 6 }} />
+                </a>
+              );
+            }
+            return (
+              <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
+                {url}
+              </a>
+            );
+          }
+          return <span key={idx}>{part}</span>;
+        })}
+      </>
+    );
+  };
   return (
     <OrderDetailWrap>
       <Typography variant="body1">
@@ -46,7 +75,7 @@ const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
       </Typography>
       <Typography variant="body1">
         <span className="prefix">Message: </span>
-        {post.offer?.message}
+        {renderTextWithLinks(post.offer?.message)}
       </Typography>
       <div className="payment-group-btns">
         {post.offer?.paymentMethods.map(method => {

--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -29,16 +29,17 @@ const OrderDetailWrap = styled.div`
 `;
 
 const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
-  const URL_REGEX = /(https?:\/\/[^\s]+)/g;
-  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(\?|$)/i;
+  // Use split-based parity to avoid issues with stateful global RegExp.test
+  const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
+  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(?:[?#].*|$)/i;
 
   const renderTextWithLinks = (text?: string) => {
     if (!text) return null;
-    const parts = text.split(URL_REGEX).filter(Boolean);
+    const parts = text.split(URL_SPLIT_REGEX);
     return (
       <>
         {parts.map((part, idx) => {
-          if (URL_REGEX.test(part)) {
+          if (idx % 2 === 1) {
             const url = part.trim();
             if (IMAGE_EXT_REGEX.test(url)) {
               return (

--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -33,6 +33,38 @@ const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
   const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
   const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(?:[?#].*|$)/i;
 
+  const sanitizeUrl = (raw?: string): string | null => {
+    if (!raw || typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    const lower = trimmed.toLowerCase();
+    if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:') || lower.startsWith('file:') || lower.startsWith('blob:')) return null;
+    try {
+      const url = new URL(trimmed);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+      const port = url.port ? `:${url.port}` : '';
+      const path = encodeURI(url.pathname + url.search + url.hash);
+      return `${url.protocol}//${url.hostname}${port}${path}`;
+    } catch (e) {
+      return null;
+    }
+  };
+
+  const parseSafeHttpUrl = (urlStr: string): URL | null => {
+    try {
+      const url = new URL(urlStr);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+      if (urlStr.startsWith('data:')) return null;
+      return url;
+    } catch (e) {
+      return null;
+    }
+  };
+
+  const isSafeImageUrl = (url: URL): boolean => {
+    if (/\.svg(\?|$)/i.test(url.pathname)) return false;
+    return /\.(png|jpe?g|gif|bmp|webp)$/i.test(url.pathname);
+  };
+
   const renderTextWithLinks = (text?: string) => {
     if (!text) return null;
     const parts = text.split(URL_SPLIT_REGEX);
@@ -41,18 +73,23 @@ const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
         {parts.map((part, idx) => {
           if (idx % 2 === 1) {
             const url = part.trim();
-            if (IMAGE_EXT_REGEX.test(url)) {
+            const parsed = parseSafeHttpUrl(url);
+            const safe = sanitizeUrl(url);
+            if (parsed && isSafeImageUrl(parsed) && safe && IMAGE_EXT_REGEX.test(safe)) {
               return (
-                <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                  <img src={url} alt="attachment" style={{ maxWidth: '100%', maxHeight: 220, borderRadius: 8, display: 'block', marginTop: 6 }} />
+                <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
+                  <img src={safe} alt="attachment" style={{ maxWidth: '100%', maxHeight: 220, borderRadius: 8, display: 'block', marginTop: 6 }} />
                 </a>
               );
             }
-            return (
-              <a key={idx} href={url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                {url}
-              </a>
-            );
+            if (parsed && safe) {
+              return (
+                <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
+                  {safe}
+                </a>
+              );
+            }
+            return <span key={idx}>{url}</span>;
           }
           return <span key={idx}>{part}</span>;
         })}

--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -3,6 +3,7 @@
 import { Post } from '@bcpros/redux-store';
 import styled from '@emotion/styled';
 import { Button, Typography } from '@mui/material';
+import renderTextWithLinks from '@/src/utils/linkHelpers';
 
 const OrderDetailWrap = styled.div`
   display: flex;
@@ -29,72 +30,7 @@ const OrderDetailWrap = styled.div`
 `;
 
 const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
-  // Use split-based parity to avoid issues with stateful global RegExp.test
-  const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
-  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(?:[?#].*|$)/i;
-
-  const sanitizeUrl = (raw?: string): string | null => {
-    if (!raw || typeof raw !== 'string') return null;
-    const trimmed = raw.trim();
-    const lower = trimmed.toLowerCase();
-    if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:') || lower.startsWith('file:') || lower.startsWith('blob:')) return null;
-    try {
-      const url = new URL(trimmed);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-      const path = encodeURI(url.pathname + url.search + url.hash);
-      return `${url.protocol}//${url.host}${path}`;
-    } catch (e) {
-      return null;
-    }
-  };
-
-  const parseSafeHttpUrl = (urlStr: string): URL | null => {
-    try {
-      const url = new URL(urlStr);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-      if (urlStr.startsWith('data:')) return null;
-      return url;
-    } catch (e) {
-      return null;
-    }
-  };
-
-  const isSafeImageUrl = (url: URL): boolean => {
-    if (/\.svg(\?|$)/i.test(url.pathname)) return false;
-    return /\.(png|jpe?g|gif|bmp|webp)$/i.test(url.pathname);
-  };
-
-  const renderTextWithLinks = (text?: string) => {
-    if (!text) return null;
-    const parts = text.split(URL_SPLIT_REGEX);
-    return (
-      <>
-        {parts.map((part, idx) => {
-          if (idx % 2 === 1) {
-            const url = part.trim();
-            const parsed = parseSafeHttpUrl(url);
-            const safe = sanitizeUrl(url);
-            if (parsed && isSafeImageUrl(parsed) && safe && IMAGE_EXT_REGEX.test(safe)) {
-              return (
-                <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                  <img src={safe} alt="attachment" style={{ maxWidth: '100%', maxHeight: 220, borderRadius: 8, display: 'block', marginTop: 6 }} />
-                </a>
-              );
-            }
-            if (parsed && safe) {
-              return (
-                <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                  {safe}
-                </a>
-              );
-            }
-            return <span key={idx}>{url}</span>;
-          }
-          return <span key={idx}>{part}</span>;
-        })}
-      </>
-    );
-  };
+  // Use shared renderTextWithLinks utility
   return (
     <OrderDetailWrap>
       <Typography variant="body1">

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -34,6 +34,7 @@ import { useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
+import renderTextWithLinks from '@/src/utils/linkHelpers';
 import useAuthorization from '../Auth/use-authorization.hooks';
 import { BackupModalProps } from '../Common/BackupModal';
 
@@ -217,99 +218,7 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
     router.push(`/profile?address=${post?.account?.address}`);
   };
 
-  // Helper: find URLs in text and render image preview if URL points to an image
-  // Use split with a non-global capturing regex and rely on index parity (odd = URL)
-  const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
-  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(?:[?#].*|$)/i;
-
-  // Strict URL sanitizer to avoid XSS in href/src attributes
-  const sanitizeUrl = (raw?: string): string | null => {
-    if (!raw || typeof raw !== 'string') return null;
-    const trimmed = raw.trim();
-    const lower = trimmed.toLowerCase();
-    if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:') || lower.startsWith('file:') || lower.startsWith('blob:')) return null;
-    try {
-      const url = new URL(trimmed);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-      const port = url.port ? `:${url.port}` : '';
-      const path = encodeURI(url.pathname + url.search + url.hash);
-      return `${url.protocol}//${url.hostname}${port}${path}`;
-    } catch (e) {
-      return null;
-    }
-  };
-
-  // Parse and validate http(s) URL; returns URL object or null
-  const parseSafeHttpUrl = (urlStr: string): URL | null => {
-    try {
-      const url = new URL(urlStr);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
-      if (urlStr.startsWith('data:')) return null;
-      return url;
-    } catch (e) {
-      return null;
-    }
-  };
-
-  // Given a parsed URL, determine if it's a raster image we allow
-  const isSafeImageUrl = (url: URL): boolean => {
-    if (/\.svg(\?|$)/i.test(url.pathname)) return false;
-    return /\.(png|jpe?g|gif|bmp|webp)$/i.test(url.pathname);
-  };
-
-  // renderTextWithLinks: if loadImages is false, render image URLs as a lightweight 'View image' link
-  const renderTextWithLinks = (text?: string, loadImages = false) => {
-    if (!text) return null;
-
-    // Split keeps captured URLs as separate array elements. Do NOT filter out empty strings — parity matters.
-    const parts = text.split(URL_SPLIT_REGEX);
-
-    return (
-      <>
-        {parts.map((part, idx) => {
-          // odd indices are URLs because the regex has one capturing group
-
-          if (idx % 2 === 1) {
-            const url = part.trim();
-            const parsed = parseSafeHttpUrl(url);
-            const safe = sanitizeUrl(url);
-
-            // If it's an image and we are allowed to load images, render the <img>
-            if (parsed && isSafeImageUrl(parsed) && safe && IMAGE_EXT_REGEX.test(safe)) {
-              if (loadImages) {
-                return (
-                  <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
-                    <img src={safe} alt="attachment" style={{ maxWidth: '100%', maxHeight: 220, borderRadius: 8, display: 'block', marginTop: 6 }} />
-                  </a>
-                );
-              }
-
-              // Images not loaded yet: render a lightweight link placeholder to the image
-              return (
-                <a key={idx} href={safe ?? url} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
-                  View image
-                </a>
-              );
-            }
-
-            // Regular link for safe http(s) URLs
-            if (parsed && safe) {
-              return (
-                <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
-                  {safe}
-                </a>
-              );
-            }
-
-            return <span key={idx}>{url}</span>;
-          }
-
-          // plain text (even indices)
-          return <span key={idx}>{part}</span>;
-        })}
-      </>
-    );
-  };
+  // Use shared helpers from utils/linkHelpers
 
   const convertXECToAmount = async () => {
     if (!rateData) return 0;
@@ -368,7 +277,7 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
     <OfferShowWrapItem>
       <div className="push-offer-wrap">
           <Typography variant="body2" style={{ fontWeight: 'bold' }} onClick={handleItemClick}>
-          {renderTextWithLinks(offerData?.message, expanded) ?? ''}
+          {renderTextWithLinks(offerData?.message, { loadImages: expanded }) ?? ''}
         </Typography>
         {(accountQueryData?.getAccountByAddress.role === Role.Moderator ||
           post?.account.hash160 === selectedWalletPath?.hash160) && (
@@ -447,7 +356,7 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
             {offerData?.noteOffer && (
               <Typography variant="body2">
                 <span className="prefix">Note: </span>
-                {renderTextWithLinks(offerData.noteOffer, true)}
+                {renderTextWithLinks(offerData.noteOffer, { loadImages: true })}
               </Typography>
             )}
           </CardContent>

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -217,6 +217,62 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
     router.push(`/profile?address=${post?.account?.address}`);
   };
 
+  // Helper: find URLs in text and render image preview if URL points to an image
+  const URL_REGEX = /(https?:\/\/[^\s]+)/g;
+  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(\?|$)/i;
+
+  const renderTextWithLinks = (text?: string) => {
+    if (!text) return null;
+
+    // Split by URLs and render
+    const parts = text.split(URL_REGEX).filter(Boolean);
+
+    return (
+      <>
+        {parts.map((part, idx) => {
+          if (URL_REGEX.test(part)) {
+            const url = part.trim();
+            if (IMAGE_EXT_REGEX.test(url)) {
+              // image preview - use plain <img> to avoid Next.js external domain config issues
+              return (
+                <a
+                  key={idx}
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  onClick={e => e.stopPropagation()}
+                >
+                  <img
+                    src={url}
+                    alt="attachment"
+                    style={{ maxWidth: '100%', maxHeight: 220, borderRadius: 8, display: 'block', marginTop: 6 }}
+                  />
+                </a>
+              );
+            }
+
+            // regular link
+            return (
+              <a
+                key={idx}
+                href={url}
+                target="_blank"
+                rel="noreferrer noopener"
+                onClick={e => e.stopPropagation()}
+                style={{ color: '#1976d2' }}
+              >
+                {url}
+              </a>
+            );
+          }
+
+          // plain text
+          return <span key={idx}>{part}</span>;
+        })}
+      </>
+    );
+  };
+
   const convertXECToAmount = async () => {
     if (!rateData) return 0;
 
@@ -273,8 +329,8 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
   const OfferItem = (
     <OfferShowWrapItem>
       <div className="push-offer-wrap">
-        <Typography variant="body2" style={{ fontWeight: 'bold' }} onClick={handleItemClick}>
-          {offerData?.message}
+          <Typography variant="body2" style={{ fontWeight: 'bold' }} onClick={handleItemClick}>
+          {renderTextWithLinks(offerData?.message) ?? ''}
         </Typography>
         {(accountQueryData?.getAccountByAddress.role === Role.Moderator ||
           post?.account.hash160 === selectedWalletPath?.hash160) && (
@@ -353,7 +409,7 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
             {offerData?.noteOffer && (
               <Typography variant="body2">
                 <span className="prefix">Note: </span>
-                {offerData.noteOffer}
+                {renderTextWithLinks(offerData.noteOffer)}
               </Typography>
             )}
           </CardContent>

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -218,22 +218,23 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
   };
 
   // Helper: find URLs in text and render image preview if URL points to an image
-  const URL_REGEX = /(https?:\/\/[^\s]+)/g;
-  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(\?|$)/i;
+  // Use split with a non-global capturing regex and rely on index parity (odd = URL)
+  const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
+  const IMAGE_EXT_REGEX = /\.(png|jpe?g|gif|webp|svg)(?:[?#].*|$)/i;
 
   const renderTextWithLinks = (text?: string) => {
     if (!text) return null;
 
-    // Split by URLs and render
-    const parts = text.split(URL_REGEX).filter(Boolean);
+    // Split keeps captured URLs as separate array elements. Do NOT filter out empty strings — parity matters.
+    const parts = text.split(URL_SPLIT_REGEX);
 
     return (
       <>
         {parts.map((part, idx) => {
-          if (URL_REGEX.test(part)) {
+          // odd indices are URLs because the regex has one capturing group
+          if (idx % 2 === 1) {
             const url = part.trim();
             if (IMAGE_EXT_REGEX.test(url)) {
-              // image preview - use plain <img> to avoid Next.js external domain config issues
               return (
                 <a
                   key={idx}
@@ -266,7 +267,7 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
             );
           }
 
-          // plain text
+          // plain text (even indices)
           return <span key={idx}>{part}</span>;
         })}
       </>

--- a/apps/telegram-ecash-escrow/src/store/util.ts
+++ b/apps/telegram-ecash-escrow/src/store/util.ts
@@ -218,9 +218,9 @@ export function sanitizeUrl(raw?: string): string | null {
   try {
     const u = new URL(trimmed);
     if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
--    const port = u.port ? `:${u.port}` : '';
--    const path = encodeURI(u.pathname + u.search + u.hash);
-    return `${u.protocol}//${u.hostname}${u.port ? `:${u.port}` : ''}${u.pathname}${u.search}${u.hash}`;
+    const port = u.port ? `:${u.port}` : '';
+    const path = encodeURI(u.pathname + u.search + u.hash);
+    return `${u.protocol}//${u.hostname}${port}${path}`;
   } catch (e) {
     return null;
   }

--- a/apps/telegram-ecash-escrow/src/store/util.ts
+++ b/apps/telegram-ecash-escrow/src/store/util.ts
@@ -242,6 +242,6 @@ export const parseSafeHttpUrl = (urlStr: string): URL | null => {
 export const isSafeImageUrl = (url: URL): boolean => {
   if (!url) return false;
   if (/\.svg(?:[?#].*)?$/i.test(url.pathname)) return false;
-  return IMAGE_EXT_REGEX.test(url.pathname + (url.search || '') + (url.hash || ''));
+  return IMAGE_EXT_REGEX.test(url.pathname);
 };
 

--- a/apps/telegram-ecash-escrow/src/store/util.ts
+++ b/apps/telegram-ecash-escrow/src/store/util.ts
@@ -218,9 +218,8 @@ export function sanitizeUrl(raw?: string): string | null {
   try {
     const u = new URL(trimmed);
     if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
-    const port = u.port ? `:${u.port}` : '';
-    const path = encodeURI(u.pathname + u.search + u.hash);
-    return `${u.protocol}//${u.hostname}${port}${path}`;
+    // Reconstruct URL from URL object parts to avoid double-encoding. Use hostname + port + pathname + search + hash.
+    return `${u.protocol}//${u.hostname}${u.port ? ':' + u.port : ''}${u.pathname}${u.search}${u.hash}`;
   } catch (e) {
     return null;
   }
@@ -242,6 +241,7 @@ export const parseSafeHttpUrl = (urlStr: string): URL | null => {
 export const isSafeImageUrl = (url: URL): boolean => {
   if (!url) return false;
   if (/\.svg(?:[?#].*)?$/i.test(url.pathname)) return false;
+  // Only check the pathname for image file extensions. Query string or hash should not be considered.
   return IMAGE_EXT_REGEX.test(url.pathname);
 };
 

--- a/apps/telegram-ecash-escrow/src/store/util.ts
+++ b/apps/telegram-ecash-escrow/src/store/util.ts
@@ -218,9 +218,9 @@ export function sanitizeUrl(raw?: string): string | null {
   try {
     const u = new URL(trimmed);
     if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
-    const port = u.port ? `:${u.port}` : '';
-    const path = encodeURI(u.pathname + u.search + u.hash);
-    return `${u.protocol}//${u.hostname}${port}${path}`;
+-    const port = u.port ? `:${u.port}` : '';
+-    const path = encodeURI(u.pathname + u.search + u.hash);
+    return `${u.protocol}//${u.hostname}${u.port ? `:${u.port}` : ''}${u.pathname}${u.search}${u.hash}`;
   } catch (e) {
     return null;
   }

--- a/apps/telegram-ecash-escrow/src/utils/linkHelpers.tsx
+++ b/apps/telegram-ecash-escrow/src/utils/linkHelpers.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { parseSafeHttpUrl, isSafeImageUrl, sanitizeUrl } from '@/src/store/util';
+
+// Split regex (capturing) — non-global to avoid RegExp.state issues.
+const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
+
+export function renderTextWithLinks(text?: string | null, options: { loadImages?: boolean } = {}) {
+  if (!text) return null;
+  const parts = text.split(URL_SPLIT_REGEX);
+  return (
+    <>
+      {parts.map((part, idx) => {
+        if (idx % 2 === 1) {
+          const rawUrl = part.trim();
+          const parsed = parseSafeHttpUrl(rawUrl);
+          if (!parsed) return <span key={idx}>{rawUrl}</span>;
+          const safe = sanitizeUrl(parsed.toString());
+          if (!safe) return <span key={idx}>{rawUrl}</span>;
+
+          if (isSafeImageUrl(parsed)) {
+            if (options.loadImages) {
+              return (
+                <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()}>
+                  <img
+                    src={safe}
+                    alt="attachment"
+                    style={{ maxWidth: '100%', maxHeight: 300, borderRadius: 8, display: 'block', marginTop: 8 }}
+                    loading="lazy"
+                  />
+                </a>
+              );
+            }
+
+            return (
+              <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
+                View image
+              </a>
+            );
+          }
+
+          return (
+            <a key={idx} href={safe} target="_blank" rel="noreferrer noopener" onClick={e => e.stopPropagation()} style={{ color: '#1976d2' }}>
+              {safe}
+            </a>
+          );
+        }
+
+        return <span key={idx}>{part}</span>;
+      })}
+    </>
+  );
+}
+
+export default renderTextWithLinks;

--- a/apps/telegram-ecash-escrow/src/utils/linkHelpers.tsx
+++ b/apps/telegram-ecash-escrow/src/utils/linkHelpers.tsx
@@ -4,7 +4,10 @@ import { parseSafeHttpUrl, isSafeImageUrl, sanitizeUrl } from '@/src/store/util'
 // Split regex (capturing) — non-global to avoid RegExp.state issues.
 const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;
 
-export function renderTextWithLinks(text?: string | null, options: { loadImages?: boolean } = {}) {
+export function renderTextWithLinks(
+  text?: string | null,
+  options: { loadImages?: boolean } = {}
+) {
   if (!text) return null;
   const parts = text.split(URL_SPLIT_REGEX);
   return (
@@ -14,9 +17,7 @@ export function renderTextWithLinks(text?: string | null, options: { loadImages?
           const rawUrl = part.trim();
           const parsed = parseSafeHttpUrl(rawUrl);
           if (!parsed) return <span key={idx}>{rawUrl}</span>;
-          const safe = sanitizeUrl(parsed.toString());
-          if (!safe) return <span key={idx}>{rawUrl}</span>;
-
+          const safe = parsed.href; // URL.href is already normalized
           if (isSafeImageUrl(parsed)) {
             if (options.loadImages) {
               return (


### PR DESCRIPTION
Add URL detection and inline image preview in Create Offer preview. Renders images/links in Offer list/detail. See commit for details and testing steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headline, message and note text now auto-detect URLs and render clickable links and optional inline image previews across offer list, detail view and create-offer UI.
  * Offer detail view shows extra post metadata (post ID, offered at, price text, amount).

* **Bug Fixes / Safety**
  * URL handling now sanitizes and restricts to safe HTTP/HTTPS, blocks unsafe schemes, and limits image previews to common raster formats (no SVG); image links open safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->