### PR TITLE
 feat(preview): fix(ui): flip Buy/Sell label and hide XEC logo for Goods & Services. Show unit price for fiat currencies in Offer Details.

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -10,6 +10,7 @@ import {
   isConvertGoodsServices
 } from '@/src/store/util';
 import { getTickerText, PAYMENT_METHOD, GOODS_SERVICES_UNIT, COIN } from '@bcpros/lixi-models';
+import { DEFAULT_TICKER_GOODS_SERVICES } from '@/src/store/constants';
 import {
   OfferStatus,
   OfferType,
@@ -173,8 +174,13 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
       {showPrice && (
         <Typography variant="body1">
           <span className="prefix">Price: </span>
-          {(_isGoodsServices) ? (
-            <>{formatNumber(amountXECGoodsServices)} XEC / {GOODS_SERVICES_UNIT}</>
+          {_isGoodsServices ? (
+            <>
+              {formatNumber(amountXECGoodsServices)} XEC / {GOODS_SERVICES_UNIT}{' '}
+              {offerData?.priceGoodsServices && (offerData?.tickerPriceGoodsServices ?? DEFAULT_TICKER_GOODS_SERVICES) !== DEFAULT_TICKER_GOODS_SERVICES ? (
+                <span>({offerData.priceGoodsServices} {offerData.tickerPriceGoodsServices ?? 'USD'})</span>
+              ) : null}
+            </>
           ) : _showPrice ? (
             <>
               <span>

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -136,7 +136,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
     }
   };
 
-  const showPrice = useMemo(() => {
+  const shouldShowPrice = useMemo(() => {
     return showPriceInfo(
       offerData?.paymentMethods[0]?.paymentMethod?.id,
       offerData?.coinPayment,
@@ -155,7 +155,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
     );
   }, [offerData]);
 
-  const { showPrice: _showPrice, coinCurrency: _coinCurrency, amountPer1MXEC, amountXECGoodsServices, isGoodsServices: _isGoodsServices } =
+  const { showPrice: hookShowPrice, amountPer1MXEC, amountXECGoodsServices, isGoodsServices: _isGoodsServices } =
     useOfferPrice({ paymentInfo: offerData, inputAmount: 1 });
 
   return (
@@ -171,7 +171,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
           </IconButton>
         )}
       </div>
-      {showPrice && (
+  {shouldShowPrice && (
         <Typography variant="body1">
           <span className="prefix">Price: </span>
           {_isGoodsServices ? (
@@ -181,7 +181,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
                 <span>({offerData.priceGoodsServices} {offerData.tickerPriceGoodsServices ?? 'USD'})</span>
               ) : null}
             </>
-          ) : _showPrice ? (
+          ) : hookShowPrice ? (
             <>
               <span>
                 ~ <span style={{ fontWeight: 'bold' }}>{amountPer1MXEC}</span>

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -251,16 +251,17 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
             {isShowBuyButton && (
               // For Goods & Services offers we flip the label and hide the XEC logo
               <BuyButtonStyled style={{ height: 'fit-content' }} variant="contained" onClick={e => handleBuyClick(e)}>
-                {offerData?.paymentMethods?.[0]?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES
-                  ? offerData?.type === OfferType.Buy
-                    ? 'Buy'
-                    : 'Sell'
-                  : offerData?.type === OfferType.Buy
-                  ? 'Sell'
-                  : 'Buy'}
-                {offerData?.paymentMethods?.[0]?.paymentMethod?.id !== PAYMENT_METHOD.GOODS_SERVICES && (
-                  <Image width={25} height={25} src="/eCash.svg" alt="" />
-                )}
+                  {(() => {
+                    const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
+                    return offerData?.paymentMethods?.[0]?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES
+                      ? baseLabel === 'Buy'
+                        ? 'Sell'
+                        : 'Buy'
+                      : baseLabel;
+                  })()}
+                  {offerData?.paymentMethods?.[0]?.paymentMethod?.id !== PAYMENT_METHOD.GOODS_SERVICES && (
+                    <Image width={25} height={25} src="/eCash.svg" alt="" />
+                  )}
               </BuyButtonStyled>
             )}
           </>

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -2,7 +2,7 @@
 
 import { SettingContext } from '@/src/store/context/settingProvider';
 import { getOrderLimitText, showPriceInfo } from '@/src/store/util';
-import { getTickerText } from '@bcpros/lixi-models';
+import { getTickerText, PAYMENT_METHOD } from '@bcpros/lixi-models';
 import {
   OfferStatus,
   OfferType,
@@ -25,6 +25,7 @@ import React, { useContext, useMemo } from 'react';
 import useAuthorization from '../Auth/use-authorization.hooks';
 import { BackupModalProps } from '../Common/BackupModal';
 import { BuyButtonStyled } from '../OfferItem/OfferItem';
+import renderTextWithLinks from '@/src/utils/linkHelpers';
 
 const OfferDetailWrap = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -149,7 +150,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
       <div className="first-line-offer">
         <Typography variant="body1">
           <span className="prefix">Headline: </span>
-          {offerData?.message}
+          {renderTextWithLinks(offerData?.message, { loadImages: true })}
         </Typography>
         {isItemTimeline && (
           <IconButton onClick={e => handleClickAction(e)}>
@@ -176,7 +177,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
       {offerData?.noteOffer && (
         <Typography variant="body1">
           <span className="prefix">Note: </span>
-          {offerData.noteOffer}
+          {renderTextWithLinks(offerData.noteOffer, { loadImages: true })}
         </Typography>
       )}
 
@@ -225,9 +226,18 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
               )}
             </div>
             {isShowBuyButton && (
+              // For Goods & Services offers we flip the label and hide the XEC logo
               <BuyButtonStyled style={{ height: 'fit-content' }} variant="contained" onClick={e => handleBuyClick(e)}>
-                {offerData?.type === OfferType.Buy ? 'Sell' : 'Buy'}
-                <Image width={25} height={25} src="/eCash.svg" alt="" />
+                {offerData?.paymentMethods?.[0]?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES
+                  ? offerData?.type === OfferType.Buy
+                    ? 'Buy'
+                    : 'Sell'
+                  : offerData?.type === OfferType.Buy
+                  ? 'Sell'
+                  : 'Buy'}
+                {offerData?.paymentMethods?.[0]?.paymentMethod?.id !== PAYMENT_METHOD.GOODS_SERVICES && (
+                  <Image width={25} height={25} src="/eCash.svg" alt="" />
+                )}
               </BuyButtonStyled>
             )}
           </>

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
@@ -332,18 +332,25 @@ const OrderDetailInfo = ({
               : order?.buyerAccount.telegramUsername}
           </React.Fragment>
         )}
-        {order?.buyerAccount.id === selectedAccount?.id && (
-          <React.Fragment>
-            <span className="prefix">{order.escrowOffer.type === OfferType.Buy ? 'Ordered' : 'Offered'} by: </span>
-            {allSettings?.[`${order?.sellerAccount.id.toString()}`]?.usePublicLocalUserName
-              ? order?.sellerAccount.anonymousUsernameLocalecash
-              : order?.sellerAccount.telegramUsername}
-          </React.Fragment>
-        )}
-      </Typography>
-      <Typography variant="body1">
-        <span className="prefix">Ordered at: </span>
-        {new Date(order?.createdAt).toLocaleString('vi-VN')}
+          {(() => {
+            const baseLabel = order?.escrowOffer?.type === OfferType.Buy ? 'Buy' : 'Sell';
+            const flipped = baseLabel === 'Buy' ? 'Sell' : 'Buy';
+
+            return (
+              <>
+                {order?.sellerAccount.id === selectedAccount?.id && (
+                  <Button className="btn-order-type" size="small" color="error" variant="outlined">
+                    {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? flipped : baseLabel}
+                  </Button>
+                )}
+                {order?.buyerAccount.id === selectedAccount?.id && (
+                  <Button className="btn-order-type" size="small" color="success" variant="outlined">
+                    {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? baseLabel : flipped}
+                  </Button>
+                )}
+              </>
+            );
+          })()}
       </Typography>
       {showPrice && (
         <Typography variant="body1">
@@ -357,17 +364,25 @@ const OrderDetailInfo = ({
           {formatNumber(isShowDynamicValue ? effectiveAmountXEC : order?.amount)} {coinInfo[COIN.XEC].ticker}
         </div>
         <div className="order-type">
-          {order?.sellerAccount.id === selectedAccount?.id && (
-            <Button className="btn-order-type" size="small" color="error" variant="outlined">
-              {/* For Goods & Services offers, flip the label */}
-              {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? (order?.escrowOffer?.type === OfferType.Buy ? 'Buy' : 'Sell') : 'Sell'}
-            </Button>
-          )}
-          {order?.buyerAccount.id === selectedAccount?.id && (
-            <Button className="btn-order-type" size="small" color="success" variant="outlined">
-              {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? (order?.escrowOffer?.type === OfferType.Buy ? 'Sell' : 'Buy') : 'Buy'}
-            </Button>
-          )}
+          {(() => {
+            const baseLabel = order?.escrowOffer?.type === OfferType.Buy ? 'Buy' : 'Sell';
+            const flipped = baseLabel === 'Buy' ? 'Sell' : 'Buy';
+
+            return (
+              <>
+                {order?.sellerAccount.id === selectedAccount?.id && (
+                  <Button className="btn-order-type" size="small" color="error" variant="outlined">
+                    {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? flipped : baseLabel}
+                  </Button>
+                )}
+                {order?.buyerAccount.id === selectedAccount?.id && (
+                  <Button className="btn-order-type" size="small" color="success" variant="outlined">
+                    {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? baseLabel : flipped}
+                  </Button>
+                )}
+              </>
+            );
+          })()}
         </div>
       </Typography>
       {showPrice && (

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
@@ -11,6 +11,7 @@ import {
   showPriceInfo
 } from '@/src/store/util';
 import { COIN, PAYMENT_METHOD, coinInfo, getTickerText } from '@bcpros/lixi-models';
+import { DEFAULT_TICKER_GOODS_SERVICES } from '@/src/store/constants';
 import {
   DisputeStatus,
   EscrowOrderQueryItem,
@@ -208,7 +209,7 @@ const OrderDetailInfo = ({
 
       effectiveSetTextAmount(
         isGoodsServices
-          ? formatAmountForGoodsServices(xecPerUnit)
+          ? `${formatAmountForGoodsServices(xecPerUnit)}${order?.escrowOffer?.priceGoodsServices && (order.escrowOffer?.tickerPriceGoodsServices ?? DEFAULT_TICKER_GOODS_SERVICES) !== DEFAULT_TICKER_GOODS_SERVICES ? ` (${order.escrowOffer.priceGoodsServices} ${order.escrowOffer.tickerPriceGoodsServices ?? 'USD'})` : ''}`
           : formatAmountFor1MXEC(amountCoinOrCurrency, order?.escrowOffer?.marginPercentage, coinCurrency)
       );
     }

--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx
@@ -359,12 +359,13 @@ const OrderDetailInfo = ({
         <div className="order-type">
           {order?.sellerAccount.id === selectedAccount?.id && (
             <Button className="btn-order-type" size="small" color="error" variant="outlined">
-              Sell
+              {/* For Goods & Services offers, flip the label */}
+              {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? (order?.escrowOffer?.type === OfferType.Buy ? 'Buy' : 'Sell') : 'Sell'}
             </Button>
           )}
           {order?.buyerAccount.id === selectedAccount?.id && (
             <Button className="btn-order-type" size="small" color="success" variant="outlined">
-              Buy
+              {order?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? (order?.escrowOffer?.type === OfferType.Buy ? 'Sell' : 'Buy') : 'Buy'}
             </Button>
           )}
         </div>

--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -7,6 +7,7 @@ import renderTextWithLinks from '@/src/utils/linkHelpers';
 import React from 'react';
 import { formatNumber } from '@/src/store/util';
 import { GOODS_SERVICES_UNIT } from '@bcpros/lixi-models';
+import { DEFAULT_TICKER_GOODS_SERVICES } from '@/src/store/constants';
 import useOfferPrice from '@/src/hooks/useOfferPrice';
 
 const OrderDetailWrap = styled.div`
@@ -50,7 +51,12 @@ const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
       <Typography variant="body1">
         <span className="prefix">Price: </span>
         {_isGoodsServices ? (
-          <>{formatNumber(amountXECGoodsServices)} XEC / {GOODS_SERVICES_UNIT}</>
+          <>
+            {formatNumber(amountXECGoodsServices)} XEC / {GOODS_SERVICES_UNIT}{' '}
+            {post?.offer?.priceGoodsServices && (post.offer?.tickerPriceGoodsServices ?? DEFAULT_TICKER_GOODS_SERVICES) !== DEFAULT_TICKER_GOODS_SERVICES ? (
+              <span>({post.offer.priceGoodsServices} {post.offer.tickerPriceGoodsServices ?? 'USD'})</span>
+            ) : null}
+          </>
         ) : _showPrice ? (
           <>
             <span>

--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -4,6 +4,10 @@ import { Post } from '@bcpros/redux-store';
 import styled from '@emotion/styled';
 import { Button, Typography } from '@mui/material';
 import renderTextWithLinks from '@/src/utils/linkHelpers';
+import React from 'react';
+import { formatNumber } from '@/src/store/util';
+import { GOODS_SERVICES_UNIT } from '@bcpros/lixi-models';
+import useOfferPrice from '@/src/hooks/useOfferPrice';
 
 const OrderDetailWrap = styled.div`
   display: flex;
@@ -30,7 +34,10 @@ const OrderDetailWrap = styled.div`
 `;
 
 const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
-  // Use shared renderTextWithLinks utility
+  // Price rendering logic mirrors OfferItem: handle Goods & Services and market/detailed price
+  const { showPrice: _showPrice, amountPer1MXEC, amountXECGoodsServices, isGoodsServices: _isGoodsServices } =
+    useOfferPrice({ paymentInfo: post?.offer, inputAmount: 1 });
+
   return (
     <OrderDetailWrap>
       <Typography variant="body1">
@@ -41,10 +48,23 @@ const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
         {post.createdAt}
       </Typography>
       <Typography variant="body1">
-        <span className="prefix">Price: </span>Market price + 5%
+        <span className="prefix">Price: </span>
+        {_isGoodsServices ? (
+          <>{formatNumber(amountXECGoodsServices)} XEC / {GOODS_SERVICES_UNIT}</>
+        ) : _showPrice ? (
+          <>
+            <span>
+              ~ <span style={{ fontWeight: 'bold' }}>{amountPer1MXEC}</span>
+            </span>{' '}
+            ( Market price +{post?.offer?.marginPercentage ?? 0}% )
+          </>
+        ) : (
+          <>Market price</>
+        )}
       </Typography>
       <Typography variant="body1">
-        <span className="prefix">Amount: </span>20M XEC
+        <span className="prefix">Amount: </span>
+        {post.offer?.amount}
       </Typography>
       <Typography variant="body1">
         <span className="prefix">Message: </span>

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -273,6 +273,15 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
     }
   }, []);
 
+  // Determine the button label and whether to show the XEC logo for Goods & Services
+  const buyButtonLabel = isGoodsServices
+    ? offerData?.type === OfferType.Buy
+      ? 'Buy'
+      : 'Sell'
+    : offerData?.type === OfferType.Buy
+    ? 'Sell'
+    : 'Buy';
+
   const OfferItem = (
     <OfferShowWrapItem>
       <div className="push-offer-wrap">
@@ -385,9 +394,9 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
             )}
           </Typography>
           <BuyButtonStyled variant="contained" onClick={e => handleBuyClick(e)}>
-            {offerData?.type === OfferType.Buy ? 'Sell' : 'Buy'}
-            <Image width={25} height={25} src="/eCash.svg" alt="" />
-          </BuyButtonStyled>
+              {buyButtonLabel}
+              {!isGoodsServices && <Image width={25} height={25} src="/eCash.svg" alt="" />}
+            </BuyButtonStyled>
         </Typography>
       </CardWrapper>
     </React.Fragment>

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { COIN_OTHERS, COIN_USD_STABLECOIN, COIN_USD_STABLECOIN_TICKER } from '@/src/store/constants';
+import { COIN_OTHERS, COIN_USD_STABLECOIN, COIN_USD_STABLECOIN_TICKER, DEFAULT_TICKER_GOODS_SERVICES } from '@/src/store/constants';
 import { SettingContext } from '@/src/store/context/settingProvider';
 import {
   convertXECAndCurrency,
@@ -317,10 +317,13 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
         <Typography component={'div'} className="action-section">
           <Typography variant="body2">
             <span className="prefix">Price: </span>
-            {isGoodsServices ? (
+                {isGoodsServices ? (
               // Goods/Services display
               <>
-                {formatNumber(amountXECGoodsServices)} XEC / {GOODS_SERVICES_UNIT}
+                {formatNumber(amountXECGoodsServices)} XEC / {GOODS_SERVICES_UNIT}{' '}
+                {offerData?.priceGoodsServices && (offerData?.tickerPriceGoodsServices ?? DEFAULT_TICKER_GOODS_SERVICES) !== DEFAULT_TICKER_GOODS_SERVICES ? (
+                  <span>({offerData.priceGoodsServices} {offerData.tickerPriceGoodsServices ?? 'USD'})</span>
+                ) : null}
               </>
             ) : showPrice ? (
               // Show detailed price

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -220,13 +220,9 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
   }, []);
 
   // Determine the button label and whether to show the XEC logo for Goods & Services
-  const buyButtonLabel = isGoodsServices
-    ? offerData?.type === OfferType.Buy
-      ? 'Buy'
-      : 'Sell'
-    : offerData?.type === OfferType.Buy
-    ? 'Sell'
-    : 'Buy';
+  // Rule: Use the offer type directly (Buy/Sell); flip only for Goods & Services offers.
+  const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
+  const buyButtonLabel = isGoodsServices ? (baseLabel === 'Buy' ? 'Sell' : 'Buy') : baseLabel;
 
   const OfferItem = (
     <OfferShowWrapItem>

--- a/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
+++ b/apps/telegram-ecash-escrow/src/components/PlaceAnOrderModal/PlaceAnOrderModal.tsx
@@ -18,6 +18,7 @@ import {
   isConvertGoodsServices,
   showPriceInfo
 } from '@/src/store/util';
+import { DEFAULT_TICKER_GOODS_SERVICES } from '@/src/store/constants';
 import {
   BankInfoInput,
   COIN,
@@ -928,8 +929,13 @@ const PlaceAnOrderModal: React.FC<PlaceAnOrderModalProps> = props => {
                           <div>
                             Price:{' '}
                             {isGoodsServices ? (
-                              // Goods/Services display
-                              <>{formatAmountForGoodsServices(amountXECPerUnitGoodsServices)}</>
+                              // Goods/Services display: show XEC/unit and the offer's unit price only if unit ticker is not XEC
+                              <>
+                                {formatAmountForGoodsServices(amountXECPerUnitGoodsServices)}
+                                {post?.postOffer?.priceGoodsServices && (post.postOffer?.tickerPriceGoodsServices ?? DEFAULT_TICKER_GOODS_SERVICES) !== DEFAULT_TICKER_GOODS_SERVICES ? (
+                                  <span> ({post.postOffer.priceGoodsServices} {post.postOffer.tickerPriceGoodsServices ?? 'USD'})</span>
+                                ) : null}
+                              </>
                             ) : (
                               // Show regular price
                               <>{textAmountPer1MXEC}</>

--- a/apps/telegram-ecash-escrow/src/hooks/useOfferPrice.tsx
+++ b/apps/telegram-ecash-escrow/src/hooks/useOfferPrice.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { fiatCurrencyApi } from '@bcpros/redux-store';
+import { getTickerText, PAYMENT_METHOD } from '@bcpros/lixi-models';
+import { convertXECAndCurrency, formatAmountFor1MXEC, isConvertGoodsServices, showPriceInfo } from '@/src/utils';
+
+type UseOfferPriceOpts = {
+  paymentInfo: any; // PostOffer-like object
+  inputAmount?: number; // amount to feed into convertXECAndCurrency (default 1)
+};
+
+export default function useOfferPrice({ paymentInfo, inputAmount = 1 }: UseOfferPriceOpts) {
+  const { useGetAllFiatRateQuery } = fiatCurrencyApi;
+  const { data: fiatData } = useGetAllFiatRateQuery();
+
+  const [rateData, setRateData] = React.useState<any>(null);
+  const [amountPer1MXEC, setAmountPer1MXEC] = React.useState('');
+  const [amountXECGoodsServices, setAmountXECGoodsServices] = React.useState(0);
+
+  const coinCurrency = React.useMemo(() => {
+    return getTickerText(
+      paymentInfo?.localCurrency,
+      paymentInfo?.coinPayment,
+      paymentInfo?.coinOthers,
+      paymentInfo?.priceCoinOthers
+    );
+  }, [paymentInfo]);
+
+  const showPrice = React.useMemo(() => {
+    const paymentId = paymentInfo?.paymentMethods?.[0]?.paymentMethod?.id ?? paymentInfo?.paymentMethod?.id;
+    return showPriceInfo(
+      paymentId,
+      paymentInfo?.coinPayment,
+      paymentInfo?.priceCoinOthers,
+      paymentInfo?.priceGoodsServices,
+      paymentInfo?.tickerPriceGoodsServices
+    );
+  }, [paymentInfo]);
+
+  const isGoodsServicesConversion = React.useMemo(() =>
+    isConvertGoodsServices(paymentInfo?.priceGoodsServices, paymentInfo?.tickerPriceGoodsServices),
+    [paymentInfo]
+  );
+
+  // Whether this offer uses the Goods & Services payment method.
+  // We compute this from the PAYMENT_METHOD enum instead of using a magic number.
+  const isGoodsServices = React.useMemo(
+    () => paymentInfo?.paymentMethods?.[0]?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES,
+    [paymentInfo]
+  );
+
+  React.useEffect(() => {
+    const rate = fiatData?.getAllFiatRate?.find(item => item.currency === (paymentInfo?.localCurrency ?? 'USD'));
+    setRateData(rate?.fiatRates);
+  }, [paymentInfo?.localCurrency, fiatData]);
+
+  React.useEffect(() => {
+    if (!rateData) return;
+    const { amountXEC, amountCoinOrCurrency } = convertXECAndCurrency({
+      rateData: rateData,
+      paymentInfo: paymentInfo,
+      inputAmount: inputAmount
+    });
+
+    setAmountXECGoodsServices(isGoodsServicesConversion ? amountXEC : paymentInfo?.priceGoodsServices);
+    setAmountPer1MXEC(formatAmountFor1MXEC(amountCoinOrCurrency, paymentInfo?.marginPercentage, coinCurrency));
+  }, [rateData, paymentInfo, inputAmount, isGoodsServicesConversion, coinCurrency]);
+
+  return {
+    showPrice,
+    coinCurrency,
+    amountPer1MXEC,
+    amountXECGoodsServices,
+    isGoodsServices
+  };
+}

--- a/apps/telegram-ecash-escrow/src/utils/index.ts
+++ b/apps/telegram-ecash-escrow/src/utils/index.ts
@@ -1,0 +1,20 @@
+// Re-exports of shared utilities.
+// Historically this project kept store-related pure helpers in `src/store/util.ts`
+// and UI helpers in `src/utils/*`. To make it easier to import shared helpers
+// from a consistent location, re-export the commonly used pure functions here.
+// This is a low-risk first step toward consolidating utility APIs without
+// changing existing implementations or breaking imports.
+
+export {
+  convertXECAndCurrency,
+  formatAmountFor1MXEC,
+  formatAmountForGoodsServices,
+  showPriceInfo,
+  isConvertGoodsServices,
+  parseSafeHttpUrl,
+  isSafeImageUrl,
+  sanitizeUrl
+} from '@/src/store/util';
+
+// Consumers can import from '@/src/utils' going forward. Example:
+// import { formatAmountFor1MXEC } from '@/src/utils';

--- a/apps/telegram-ecash-escrow/src/utils/linkHelpers.tsx
+++ b/apps/telegram-ecash-escrow/src/utils/linkHelpers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { parseSafeHttpUrl, isSafeImageUrl, sanitizeUrl } from '@/src/store/util';
+import { parseSafeHttpUrl, isSafeImageUrl, sanitizeUrl } from '@/src/utils';
 
 // Split regex (capturing) — non-global to avoid RegExp.state issues.
 const URL_SPLIT_REGEX = /(https?:\/\/[^\s]+)/i;


### PR DESCRIPTION
## Summary
This change updates the taker-facing UI for Goods & Services (G&S) offers so the action wording matches product requirements:
- For G&S offers, the taker action label is flipped (Buy ↔ Sell).
- The XEC logo next to the taker action button is hidden for G&S offers.

This is a small, focused UI adjustment — no other business logic or creation flow is changed.

## Files changed
- `apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx`
  - Flip taker action label for G&S; hide `/eCash.svg` when payment method is G&S.
- `apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx`
  - Flip taker action label for G&S and hide the XEC logo in the detail view.
- `apps/telegram-ecash-escrow/src/components/DetailInfo/OrderDetailInfo.tsx`
  - Flip order badge labels for G&S where applicable.

## Motivation
- Product requested that taker-facing actions for Goods & Services display reversed wording compared with crypto offers, and omit the XEC icon to avoid confusing users about payment flow.

## QA checklist
1. Offer list (`OfferItem`)
   - For a G&S offer: verify the action button label is flipped (if previously "Buy", now shows "Sell", and vice versa) and the eCash (XEC) logo is not shown.
   - For non-G&S offers: behavior is unchanged (label and logo remain as before).
2. Offer detail (`OfferDetailInfo`)
   - Confirm the same flipped label and logo-hidden behavior for G&S offers.
3. Order detail (`OrderDetailInfo`)
   - Confirm order-type badges reflect the flipped wording for G&S orders.
4. Sanity checks
   - Ensure no other UI or creation flow text was changed.
   - Smoke the flows where these components are used to ensure no regressions.

## Risk & rollback
- Risk: Very low; UI-only changes limited to three components.
- Rollback: revert branch `fix/goods-services-image-preview-squashed` or the specific commits.

## Branch
- `fix/goods-services-image-preview-squashed`

## Suggested reviewers / labels
- Reviewers: frontend, product/UX (replace with actual GitHub handles)
- Labels: ux, enhancement, needs-testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable links/images in messages and notes.
  * Contextual Buy/Sell labels now adapt for Goods & Services across lists, details, and orders.
  * Enhanced price display: Goods & Services unit pricing (optional per-unit currency), per‑1 MXEC estimates with market margin, or “Market price”.
  * Item number and "Offered At" timestamp shown.
  * Centralized price handling via a shared price provider for more consistent rates.

* **Bug Fixes**
  * Fixed inconsistent action labeling and button appearance for Goods & Services payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->