### PR TITLE
fix(offer-detail): replace non-existent offer.amount with getOrderLimitText to avoid build error

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferDetailInfo/OfferDetailInfo.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { Button, Typography } from '@mui/material';
 import renderTextWithLinks from '@/src/utils/linkHelpers';
 import React from 'react';
-import { formatNumber } from '@/src/store/util';
+import { formatNumber, getOrderLimitText } from '@/src/store/util';
 import { GOODS_SERVICES_UNIT } from '@bcpros/lixi-models';
 import { DEFAULT_TICKER_GOODS_SERVICES } from '@/src/store/constants';
 import useOfferPrice from '@/src/hooks/useOfferPrice';
@@ -70,7 +70,7 @@ const OrderDetailInfo = ({ key, post }: { key: string; post: Post }) => {
       </Typography>
       <Typography variant="body1">
         <span className="prefix">Amount: </span>
-        {post.offer?.amount}
+        {getOrderLimitText(post.offer?.orderLimitMin, post.offer?.orderLimitMax, '')}
       </Typography>
       <Typography variant="body1">
         <span className="prefix">Message: </span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated Offer Details to display the order limit range (min–max) in the Amount section with improved formatting, replacing the single-value amount. This provides clearer visibility into minimum and maximum order limits and delivers a more consistent presentation alongside price and payment information. The change applies across all offers shown in Offer Details; no other fields or behaviors were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->