### PR TITLE
fix(ui): reverse taker button labels for offers

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -261,7 +261,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
                     const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
                     return baseLabel === 'Buy' ? 'Sell' : 'Buy';
                   })()}
-                  {offerData?.paymentMethods?.[0]?.paymentMethod?.id !== PAYMENT_METHOD.GOODS_SERVICES && (
+                  {offerData?.paymentMethods?.[0]?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? null : (
                     <Image width={25} height={25} src="/eCash.svg" alt="" />
                   )}
               </BuyButtonStyled>

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -220,6 +220,7 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
   }, []);
 
   // Determine the taker-facing button label and whether to show the XEC logo
+  // Rule: Always display the opposite action from the offer type; hide the XEC logo for non-Goods & Services offers.
   // Rule: Always display the opposite action from the offer type; hide the XEC logo for Goods & Services.
   const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
   const takerButtonLabel = baseLabel === 'Buy' ? 'Sell' : 'Buy';


### PR DESCRIPTION
Summary / Intent
Fix a TypeScript build error and make taker action labels consistent across the Telegram eCash escrow UI:

Remove invalid post.offer?.amount access and show order limit text instead.
Always display the opposite action (Buy ↔ Sell) on taker buttons in list and detail views so users see the action they will perform.
Why
post.offer?.amount caused TypeScript compile errors and didn't represent min/max order limits.
Taker buttons were inconsistent between components; flipping the label makes the UX clearer for takers.
Branch / PR
Branch: fix/reverse-taker-labels
PR: [https://github.com/bcProFoundation/local-ecash/pull/386](vscode-file://vscode-app/c:/Users/nghia/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Files changed
[OfferDetailInfo.tsx](vscode-file://vscode-app/c:/Users/nghia/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Replace post.offer?.amount with getOrderLimitText(post.offer?.orderLimitMin, post.offer?.orderLimitMax, '') to show min/max limits.
[OfferItem.tsx](vscode-file://vscode-app/c:/Users/nghia/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Simplify taker button label logic: always show the opposite label (Buy → Sell, Sell → Buy). Keep hiding XEC logo for Goods & Services.
[OfferDetailInfo.tsx](vscode-file://vscode-app/c:/Users/nghia/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Mirror the taker label flip logic for the detail pane.
What changed (high level)
Swapped an invalid property access for a utility that renders order limit text.
Unified taker-label logic to a single, deterministic flip.
Kept Goods & Services behavior: XEC logo hidden where currency is irrelevant.
Test plan
Automated:

Run Playwright/spec tests in apps/localecash-testing/tests/ to check there are no regressions and TypeScript compile succeeds.
Manual:

Offer list
For a maker labeled "Buy", taker button should read "Sell".
For a maker labeled "Sell", taker button should read "Buy".
Offer detail
Verify the taker button label is reversed according to the same rule.
Confirm amount/limits area shows min/max order limits (not undefined or an invalid value).
Goods & Services offers
Confirm XEC logo is not rendered next to the taker action or amount field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected taker-facing button labels on offer lists and detail views to consistently show the opposite action (Buy ↔ Sell), independent of payment method.
  * Adjusted XEC logo visibility to display only for non–Goods & Services offers, hiding it for Goods & Services.
  * Improves clarity and consistency of actions and visuals for takers across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->