### PR TITLE
fix(ui): reverse taker button labels for offers

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -160,8 +160,8 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
 
   const takerActionLabel = useMemo(() => {
     const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
-    return _isGoodsServices ? (baseLabel === 'Buy' ? 'Sell' : 'Buy') : baseLabel;
-  }, [offerData?.type, _isGoodsServices]);
+    return baseLabel === 'Buy' ? 'Sell' : 'Buy';
+  }, [offerData?.type]);
 
   return (
     <OfferDetailWrap onClick={() => router.push(`/offer-detail?id=${offerData.postId}`)}>
@@ -260,7 +260,7 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
               )}
             </div>
             {isShowBuyButton && (
-              // Goods & Services takers see the opposite action; others keep the maker-facing label
+              // Takers always see the opposite action; Goods & Services still hide the XEC logo
               <BuyButtonStyled style={{ height: 'fit-content' }} variant="contained" onClick={e => handleBuyClick(e)}>
                 {takerActionLabel}
                 {offerData?.paymentMethods?.[0]?.paymentMethod?.id === PAYMENT_METHOD.GOODS_SERVICES ? null : (

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -220,10 +220,9 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
   }, []);
 
   // Determine the taker-facing button label and whether to show the XEC logo
-  // Goods & Services takers see the opposite action (Buy -> Sell, Sell -> Buy);
-  // all other offers keep the maker-facing label. The XEC logo stays hidden for Goods & Services.
+  // Takers always see the opposite action (Buy ↔ Sell). We still hide the XEC logo for Goods & Services offers.
   const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
-  const takerButtonLabel = isGoodsServices ? (baseLabel === 'Buy' ? 'Sell' : 'Buy') : baseLabel;
+  const takerButtonLabel = baseLabel === 'Buy' ? 'Sell' : 'Buy';
 
   const OfferItem = (
     <OfferShowWrapItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Taker-facing action buttons now consistently display the opposite action (Buy ↔ Sell) in both offer list and detail views, regardless of Goods & Services settings. This resolves cases where takers previously saw mismatched or confusing labels, ensuring clear, predictable actions across the app.
- Style
  - Unified action labeling for takers to improve clarity and consistency in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->