### PR TITLE
fix(ui): reverse taker labels only for Goods & Services offers

### DIFF
--- a/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
+++ b/apps/telegram-ecash-escrow/src/components/DetailInfo/OfferDetailInfo.tsx
@@ -160,8 +160,8 @@ const OfferDetailInfo = ({ timelineItem, post, isShowBuyButton = false, isItemTi
 
   const takerActionLabel = useMemo(() => {
     const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
-    return baseLabel === 'Buy' ? 'Sell' : 'Buy';
-  }, [offerData?.type]);
+    return _isGoodsServices ? (baseLabel === 'Buy' ? 'Sell' : 'Buy') : baseLabel;
+  }, [offerData?.type, _isGoodsServices]);
 
   return (
     <OfferDetailWrap onClick={() => router.push(`/offer-detail?id=${offerData.postId}`)}>

--- a/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
+++ b/apps/telegram-ecash-escrow/src/components/OfferItem/OfferItem.tsx
@@ -220,9 +220,9 @@ export default function OfferItem({ timelineItem }: OfferItemProps) {
   }, []);
 
   // Determine the taker-facing button label and whether to show the XEC logo
-  // Takers always see the opposite action (Buy ↔ Sell). We still hide the XEC logo for Goods & Services offers.
+  // For Goods & Services offers, taker label is reversed (Buy <-> Sell). For other categories, keep original label.
   const baseLabel = offerData?.type === OfferType.Buy ? 'Buy' : 'Sell';
-  const takerButtonLabel = baseLabel === 'Buy' ? 'Sell' : 'Buy';
+  const takerButtonLabel = isGoodsServices ? (baseLabel === 'Buy' ? 'Sell' : 'Buy') : baseLabel;
 
   const OfferItem = (
     <OfferShowWrapItem>


### PR DESCRIPTION
Reverse labels for Goods and Services from previous edits,  so that labels make more sense to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected taker action button labels: for Goods & Services offers, the label now inverts (Buy/Sell) relative to the base; for other offers, it matches the base.
  * Ensures accurate labels in both offer list and detail views.
  * Improved reactivity so labels update when the offer type or Goods & Services flag changes.
  * Clarified inline descriptions to reflect the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->